### PR TITLE
Alleen RoutePoints

### DIFF
--- a/xsd/netex-nl-met-constraints.xsd
+++ b/xsd/netex-nl-met-constraints.xsd
@@ -4194,7 +4194,7 @@
 			<xsd:field xpath="@version"/>
 		</xsd:keyref>
 		<xsd:key name="RoutePoint_AnyVersionedKey">
-			<xsd:selector xpath=".//netex:RoutePoint | .//netex:ScheduledStopPoint | .//netex:GaragePoint | .//netex:ParkingPoint | .//netex:ReliefPoint | .//netex:ActivationPoint | .//netex:TimingPoint |.//netex:FareScheduledStopPoint"/>
+			<xsd:selector xpath=".//netex:RoutePoint"/>
 			<xsd:field xpath="@id"/>
 			<xsd:field xpath="@version"/>
 		</xsd:key>


### PR DESCRIPTION
Op dit moment stelt de documentatie dat alleen RoutePoints mogen worden gebruikt als FromPointRef/ToPointRef in een RouteLink. Er is een vervoerder die geweest die de XSD heeft gevolgd en ScheduledStopPoints heeft gebruikt. Voorstel tijdens architectuurwerkgroep 7 juli 2022 is deze te beperken tot slechts RoutePoint. Transdev en OpenGeo controleren of DOVA export met ActivationPoints nu goed gaan.