### PR TITLE
Bugfix PassengerCapacity

### DIFF
--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -1101,14 +1101,10 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 		<xsd:annotation>
 		<xsd:documentation>Type for a list of PASSENGER CAPACITY REQUIREMENTs.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:complexContent>
-		<xsd:extension base="oneToManyRelationshipStructure">
-			<xsd:choice maxOccurs="unbounded">
-			<xsd:element ref="PassengerCapacityRef"/>
+		<xsd:choice maxOccurs="unbounded">
+			<xsd:element name="PassengerCapacityRef" type="VersionOfObjectRefStructure"/>
 			<xsd:element ref="PassengerCapacity" maxOccurs="1"/>
-			</xsd:choice>
-		</xsd:extension>
-		</xsd:complexContent>
+		</xsd:choice>
 	</xsd:complexType>
 	<xsd:element name="PassengerCapacity">
 		<xsd:annotation>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -1112,7 +1112,10 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 		</xsd:annotation>
 		<xsd:complexType>
 		<xsd:complexContent>
-			<xsd:extension base="PassengerCapacityStructure">
+			<xsd:extension base="DataManagedObjectStructure">
+			<xsd:sequence>
+				<xsd:group ref="PassengerCapacityGroup"/>
+			</xsd:sequence>
 			<xsd:attribute name="id" type="PassengerCapacityIdType" use="optional">
 				<xsd:annotation>
 				<xsd:documentation>Identifier of PASSENGER CAPACITY.</xsd:documentation>
@@ -1128,18 +1131,6 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 		</xsd:annotation>
 		<xsd:restriction base="ObjectIdType"/>
 	</xsd:simpleType>
-	<xsd:complexType name="PassengerCapacityStructure">
-		<xsd:annotation>
-		<xsd:documentation>Capacity for a VEHICLE TYPE and Class.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:complexContent>
-		<xsd:extension base="DataManagedObjectStructure">
-			<xsd:sequence>
-			<xsd:group ref="PassengerCapacityGroup"/>
-			</xsd:sequence>
-		</xsd:extension>
-		</xsd:complexContent>
-	</xsd:complexType>
 	<xsd:group name="PassengerCapacityGroup">
 		<xsd:annotation>
 		<xsd:documentation>Elements for a PASSENGER CAPACITY REQUIREMENT. relevant for passenger systems.</xsd:documentation>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -1112,24 +1112,13 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 		</xsd:annotation>
 		<xsd:complexType>
 		<xsd:complexContent>
-			<xsd:restriction base="PassengerCapacityStructure">
-			<xsd:sequence>
-				<xsd:sequence>
-				<xsd:group ref="EntityInVersionGroup" minOccurs="0"/>
-				</xsd:sequence>
-				<xsd:sequence>
-				<xsd:group ref="DataManagedObjectGroup"/>
-				</xsd:sequence>
-				<xsd:sequence>
-				<xsd:group ref="PassengerCapacityGroup"/>
-				</xsd:sequence>
-			</xsd:sequence>
+			<xsd:extension base="PassengerCapacityStructure">
 			<xsd:attribute name="id" type="PassengerCapacityIdType" use="optional">
 				<xsd:annotation>
 				<xsd:documentation>Identifier of PASSENGER CAPACITY.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
-			</xsd:restriction>
+			</xsd:extension>
 		</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -1137,6 +1137,12 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 		</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
+	<xsd:simpleType name="PassengerCapacityIdType">
+		<xsd:annotation>
+			<xsd:documentation>Type for identifier of a PASSENGER CAPACITY.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="ObjectIdType"/>
+	</xsd:simpleType>
 	<xsd:complexType name="PassengerCapacityStructure">
 		<xsd:annotation>
 		<xsd:documentation>Capacity for a VEHICLE TYPE and Class.</xsd:documentation>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -1112,19 +1112,31 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 		</xsd:annotation>
 		<xsd:complexType>
 		<xsd:complexContent>
-			<xsd:extension base="DataManagedObjectStructure">
+			<xsd:restriction base="PassengerCapacityStructure">
 			<xsd:sequence>
 				<xsd:group ref="PassengerCapacityGroup"/>
 			</xsd:sequence>
-			<xsd:attribute name="id" type="PassengerCapacityIdType" use="optional">
+			<xsd:attribute name="id" type="PassengerCapacityIdType" use="required" form="unqualified">
 				<xsd:annotation>
 				<xsd:documentation>Identifier of PASSENGER CAPACITY.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
-			</xsd:extension>
+			</xsd:restriction>
 		</xsd:complexContent>
 		</xsd:complexType>
 	</xsd:element>
+	<xsd:complexType name="PassengerCapacityStructure">
+		<xsd:annotation>
+			<xsd:documentation>Capacity for a VEHICLE TYPE and Class.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="DataManagedObjectStructure">
+				<xsd:sequence>
+					<xsd:group ref="PassengerCapacityGroup"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
 	<xsd:simpleType name="PassengerCapacityIdType">
 		<xsd:annotation>
 			<xsd:documentation>Type for identifier of a PASSENGER CAPACITY.</xsd:documentation>


### PR DESCRIPTION
XSD 9.2.4 trachtte het PassengerCapacity element compatibel te maken met de volledige standaard. Deze change bevatte echter een bug, waardoor de XSD invalid werd. 

Het betrof de volgende fouten:
- In passengerCapacities_RelStructure was gebaseerd op oneToManyRelationshipStructure, maar de definitie daarvoor was niet opgenomen
- PassengerCapacity verwees naar EntityInVersionGroup en DataManagedObjectGroup en het attribute PassengerCapacityIdType, maar de definities daarvoor waren niet opgenomen

Oplossing:
- De verwijzing naar oneToManyRelationshipStructure is verwijderd
- De verwijzingen naar EntityInVersionGroup en DataManagedObjectGroupis verwijderd
- PassengerCapacityIdType is opgenomen