### PR TITLE
Element limitations opgenomen in accessibilityAssessment

### DIFF
--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -629,7 +629,25 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 			<xsd:extension base="DataManagedObjectStructure">
 				<xsd:sequence>
 					<xsd:element name="MobilityImpairedAccess" type="LimitationStatusEnumeration"/>
+					<xsd:element name="limitations" type="limitationsStructure" minOccurs="0"/>
 					<xsd:element name="Comment" type="MultilingualString" minOccurs="0"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="limitationsStructure">
+		<xsd:sequence>
+			<xsd:element name="AccessibilityLimitation" type="accessibilityLimitationStructure" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="accessibilityLimitationStructure">
+		<xsd:complexContent>
+			<xsd:extension base="EmbeddedObjectStructure">
+				<xsd:sequence>
+					<xsd:element name="WheelchairAccess" type="LimitationStatusEnumeration" default="false"/>
+					<xsd:element name="StepFreeAccess" type="LimitationStatusEnumeration" default="unknown" minOccurs="0"/>
+					<xsd:element name="EscalatorFreeAccess" type="LimitationStatusEnumeration" default="unknown" minOccurs="0"/>
+					<xsd:element name="LiftFreeAccess" type="LimitationStatusEnumeration" default="unknown" minOccurs="0"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/xsd/netex-nl.xsd
+++ b/xsd/netex-nl.xsd
@@ -23,6 +23,7 @@
 <!--   v9.2.3  (jul.2021) toevoegen flexvervoer                                      -->
 <!--   v9.2.4  (dec.2022) Organsation is ofwel Operator of Authority				 -->
 <!--					  Overeenkomstig EU XSD 						             -->
+<!--   v9.3.0  (xxx.2023) Element limitations opgenomen in accessibilityAssessment   -->
 <!--                                                                                 -->
 <!-- Copyright:                                                                      -->
 <!--     Dit document is eigendom van Platform BISON onder Samenwerkingsverband DOVA -->


### PR DESCRIPTION
De tekst in het NeTEx NL document beschrijft het gebruik van o.a. StepFreeAccess binnen een AccessibilityAssessment element. De NL-XSD stond dit echter nog niet toe (CEN-XSD wel). De NL-XSD is daarom aangepast, zodat dit mogelijk wordt, waarmee document en XSD weer met elkaar overeenkomen op dit punt.