### PR TITLE
fixed="any" per elementtype gedefinieerd

### DIFF
--- a/xsd/netex-nl-basic.xsd
+++ b/xsd/netex-nl-basic.xsd
@@ -110,8 +110,7 @@
 			<xsd:maxLength value="1024"/>
 			<xsd:pattern value="(http|HTTP|https|HTTPS|ftp|FTP)://.+\.(jpg|JPG|jpeg|JPEG|gif|GIF|png|PNG|svg|SVG)">
 				<xsd:annotation>
-					<xsd:documentation>ftp/http/https (hoofdletters of kleine letters, geen combinaties);
-bestandtypes jpg, jpeg, gif, png, svg (hoofdletters of kleine letters, geen combinaties)</xsd:documentation>
+					<xsd:documentation>ftp/http/https (hoofdletters of kleine letters, geen combinaties); bestandtypes jpg, jpeg, gif, png, svg (hoofdletters of kleine letters, geen combinaties)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:pattern>
 		</xsd:restriction>
@@ -127,16 +126,13 @@ bestandtypes jpg, jpeg, gif, png, svg (hoofdletters of kleine letters, geen comb
 	</xsd:complexType>
 	<xsd:complexType name="SimpleObjectStructure">
 		<xsd:annotation>
-			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-Het object heeft geen 'version' attribuut.</xsd:documentation>
+			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. Het object heeft geen 'version' attribuut.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 	</xsd:complexType>
 	<xsd:complexType name="DataManagedObjectStructure" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-Het 'version' attribuut is nodig voor de constraints, maar in het NL NeTEx Profiel wordt dit niet per object gevarieerd.
-De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
+			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. Het 'version' attribuut is nodig voor de constraints, maar in het NL NeTEx Profiel wordt dit niet per object gevarieerd. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
@@ -144,8 +140,7 @@ De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bo
 	</xsd:complexType>
 	<xsd:complexType name="DataManagedObjectStructure-with-version" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-Bij een Version of xxxFrame is attribuut 'version' wel verplicht.</xsd:documentation>
+			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. Bij een Version of xxxFrame is attribuut 'version' wel verplicht.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="id" type="VersionIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
@@ -165,10 +160,7 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 -->
 	<xsd:complexType name="DataManagedObjectStructure-with-status" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>
-				Een element uit een voorgedefinieerde lijst heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-				De 'status' geeft aan of het element nog courant is.
-			</xsd:documentation>
+			<xsd:documentation>Een element uit een voorgedefinieerde lijst heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. De 'status' geeft aan of het element nog courant is.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" default="new" form="unqualified"/>
@@ -177,10 +169,7 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 	</xsd:complexType>
 	<xsd:complexType name="OrderedVersionOfObjectStructure" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-Het 'version' attribuut is nodig voor de constraints, maar in het NL NeTEx Profiel wordt dit niet per object gevarieerd.
-De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-Bij een object in een sequence is attribuut 'order' verplicht.</xsd:documentation>
+			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. Het 'version' attribuut is nodig voor de constraints, maar in het NL NeTEx Profiel wordt dit niet per object gevarieerd. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'. Bij een object in een sequence is attribuut 'order' verplicht.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
@@ -189,10 +178,7 @@ Bij een object in een sequence is attribuut 'order' verplicht.</xsd:documentatio
 	</xsd:complexType>
 	<xsd:complexType name="OrderedVersionOfObjectStructure-fixed" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-Het 'version' attribuut is nodig voor de constraints, maar in het NL NeTEx Profiel wordt dit niet per object gevarieerd.
-De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-Bij een object in een assignment is attribuut 'order' verplicht maar niet (altijd) zinvol.</xsd:documentation>
+			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. Het 'version' attribuut is nodig voor de constraints, maar in het NL NeTEx Profiel wordt dit niet per object gevarieerd. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'. Bij een object in een assignment is attribuut 'order' verplicht maar niet (altijd) zinvol.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
@@ -201,8 +187,7 @@ Bij een object in een assignment is attribuut 'order' verplicht maar niet (altij
 	</xsd:complexType>
 	<xsd:complexType name="VersionFrameVersionStructure">
 		<xsd:annotation>
-			<xsd:documentation>Een frame heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-Bij een frame is attribuut 'version' verplicht.</xsd:documentation>
+			<xsd:documentation>Een frame heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. Bij een frame is attribuut 'version' verplicht.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
@@ -214,8 +199,7 @@ Bij een frame is attribuut 'version' verplicht.</xsd:documentation>
 	</xsd:complexType>
 	<xsd:complexType name="TypeOfValueVersionStructure" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>Een element uit een BISON standaardenumeratie heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-Het object heeft de vaste waarde 'any' voor attribuut 'version'. Deze waarde wordt geinterpreteerd als 'de actuele versie'.</xsd:documentation>
+			<xsd:documentation>Een element uit een BISON standaardenumeratie heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. Het object heeft de vaste waarde 'any' voor attribuut 'version'. Deze waarde wordt geinterpreteerd als 'de actuele versie'.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="DataManagedObjectStructure-with-version">
@@ -228,8 +212,7 @@ Het object heeft de vaste waarde 'any' voor attribuut 'version'. Deze waarde wor
 	</xsd:complexType>
 	<xsd:complexType name="TypeOfValueVersionStructure-with-version" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>Een element uit een BISON standaardenumeratie heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-De TypeOfFrame standaardenumeraties hebben een expliciete 'version', nl. de versie van het NL NeTEx Profiel.</xsd:documentation>
+			<xsd:documentation>Een element uit een BISON standaardenumeratie heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. De TypeOfFrame standaardenumeraties hebben een expliciete 'version', nl. de versie van het NL NeTEx Profiel.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
 			<xsd:extension base="DataManagedObjectStructure-with-version">

--- a/xsd/netex-nl-basic.xsd
+++ b/xsd/netex-nl-basic.xsd
@@ -151,16 +151,6 @@ Bij een Version of xxxFrame is attribuut 'version' wel verplicht.</xsd:documenta
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
 		<xsd:attribute name="version" type="VersionIdType" use="required" form="unqualified"/>
 	</xsd:complexType>
-	<xsd:complexType name="DataManagedObjectStructure-any-version" abstract="true">
-		<xsd:annotation>
-			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-Het 'version' attribuut is nodig voor de constraints, maar heeft altijd de vaste waarde 'any'.
-De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
-		</xsd:annotation>
-		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
-		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
-		<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified"/>
-	</xsd:complexType>
 	<!--
 	<xsd:complexType name="DataManagedObjectStructure-modified" abstract="true">
 		<xsd:annotation>
@@ -175,14 +165,15 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 -->
 	<xsd:complexType name="DataManagedObjectStructure-with-status" abstract="true">
 		<xsd:annotation>
-			<xsd:documentation>Een element uit een voorgedefinieerde lijst heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
-Het object heeft geen expliciete 'version'. De waarde 'any' wordt geinterpreteerd als 'de actuele versie'.
-De 'status' geeft aan of het element nog courant is.</xsd:documentation>
+			<xsd:documentation>
+				Een element uit een voorgedefinieerde lijst heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
+				De 'status' geeft aan of het element nog courant is.
+			</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
-		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
-		<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified"/>
-		<xsd:attribute name="status" type="StatusEnumeration" use="optional" default="active" form="unqualified"/>
+		<xsd:attribute name="modification" type="ModificationEnumeration" default="new" form="unqualified"/>
+		<xsd:attribute name="version" type="VersionIdType" use="required" form="unqualified"/>
+		<xsd:attribute name="status" type="StatusEnumeration" default="active" form="unqualified"/>
 	</xsd:complexType>
 	<xsd:complexType name="OrderedVersionOfObjectStructure" abstract="true">
 		<xsd:annotation>
@@ -227,7 +218,7 @@ Bij een frame is attribuut 'version' verplicht.</xsd:documentation>
 Het object heeft de vaste waarde 'any' voor attribuut 'version'. Deze waarde wordt geinterpreteerd als 'de actuele versie'.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="DataManagedObjectStructure-any-version">
+			<xsd:extension base="DataManagedObjectStructure-with-version">
 				<xsd:sequence>
 					<xsd:element name="Name" type="MultilingualString"/>
 					<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -149,7 +149,7 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 					<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
 				</xsd:sequence>
 			</xsd:extension>
-		</xsd:complexContent>	
+		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="operator">
 		<xsd:complexContent>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -86,8 +86,7 @@
 		<xsd:complexContent>
 			<xsd:extension base="DataManagedObjectStructure-with-version">
 				<xsd:annotation>
-					<xsd:documentation>Identificatie van de levering.
-Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attribuut 'version' van het CompositeFrame.</xsd:documentation>
+					<xsd:documentation>Identificatie van de levering. Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attribuut 'version' van het CompositeFrame.</xsd:documentation>
 				</xsd:annotation>
 				<xsd:sequence>
 					<xsd:element name="StartDate" type="xsd:dateTime"/>
@@ -109,10 +108,7 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 				</xsd:sequence>
 				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
 					<xsd:annotation>
-						<xsd:documentation>
-							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
-							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-						</xsd:documentation>
+						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
@@ -131,10 +127,7 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 				</xsd:sequence>
 				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
 					<xsd:annotation>
-						<xsd:documentation>
-							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
-							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-						</xsd:documentation>
+						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -107,6 +107,14 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 					<xsd:element name="ShortName" type="MultilingualString"/>
 					<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
 				</xsd:sequence>
+				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
+					<xsd:annotation>
+						<xsd:documentation>
+							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
+							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -121,6 +129,14 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 					<xsd:element name="GroupOfLinesType" type="GroupOfLinesTypeEnumeration"/>
 					<xsd:element name="AuthorityRef" type="VersionOfObjectRefStructure"/>
 				</xsd:sequence>
+				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
+					<xsd:annotation>
+						<xsd:documentation>
+							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
+							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -133,7 +149,7 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 					<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
 				</xsd:sequence>
 			</xsd:extension>
-		</xsd:complexContent>
+		</xsd:complexContent>	
 	</xsd:complexType>
 	<xsd:complexType name="operator">
 		<xsd:complexContent>

--- a/xsd/netex-nl-enums.xsd
+++ b/xsd/netex-nl-enums.xsd
@@ -599,32 +599,86 @@
 	<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 	<xsd:complexType name="typeOfService">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure"/>
+			<xsd:extension base="TypeOfValueVersionStructure">
+				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
+					<xsd:annotation>
+						<xsd:documentation>
+							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
+							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="typeOfActivation">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure"/>
+			<xsd:extension base="TypeOfValueVersionStructure">
+				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
+					<xsd:annotation>
+						<xsd:documentation>
+							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
+							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="typeOfEquipment">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure"/>
+			<xsd:extension base="TypeOfValueVersionStructure">
+				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
+					<xsd:annotation>
+						<xsd:documentation>
+							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
+							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="typeOfResponsibilityRole">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure"/>
+			<xsd:extension base="TypeOfValueVersionStructure">
+				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
+					<xsd:annotation>
+						<xsd:documentation>
+							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
+							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="displayTextLength">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure"/>
+			<xsd:extension base="TypeOfValueVersionStructure">
+				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
+					<xsd:annotation>
+						<xsd:documentation>
+							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
+							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="typeOfFrame">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure-with-version"/>
+			<xsd:extension base="TypeOfValueVersionStructure-with-version">
+				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
+					<xsd:annotation>
+						<xsd:documentation>
+							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
+							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
+						</xsd:documentation>
+					</xsd:annotation>
+				</xsd:attribute>
+			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
 </xsd:schema>

--- a/xsd/netex-nl-enums.xsd
+++ b/xsd/netex-nl-enums.xsd
@@ -602,10 +602,7 @@
 			<xsd:extension base="TypeOfValueVersionStructure">
 				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
 					<xsd:annotation>
-						<xsd:documentation>
-							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
-							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-						</xsd:documentation>
+						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
@@ -616,10 +613,7 @@
 			<xsd:extension base="TypeOfValueVersionStructure">
 				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
 					<xsd:annotation>
-						<xsd:documentation>
-							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
-							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-						</xsd:documentation>
+						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
@@ -630,10 +624,7 @@
 			<xsd:extension base="TypeOfValueVersionStructure">
 				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
 					<xsd:annotation>
-						<xsd:documentation>
-							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
-							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-						</xsd:documentation>
+						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
@@ -644,10 +635,7 @@
 			<xsd:extension base="TypeOfValueVersionStructure">
 				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
 					<xsd:annotation>
-						<xsd:documentation>
-							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
-							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-						</xsd:documentation>
+						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
@@ -658,10 +646,7 @@
 			<xsd:extension base="TypeOfValueVersionStructure">
 				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
 					<xsd:annotation>
-						<xsd:documentation>
-							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
-							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-						</xsd:documentation>
+						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>
@@ -672,10 +657,7 @@
 			<xsd:extension base="TypeOfValueVersionStructure-with-version">
 				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
 					<xsd:annotation>
-						<xsd:documentation>
-							Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'.
-							De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.
-						</xsd:documentation>
+						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>

--- a/xsd/netex-nl.xsd
+++ b/xsd/netex-nl.xsd
@@ -705,9 +705,7 @@
 		<xsd:sequence>
 			<xsd:element name="CompositeFrame" type="compositeFrame" maxOccurs="unbounded">
 				<xsd:annotation>
-					<xsd:documentation>Bij een 'dienstregeling' levering: één CompositeFrame per partitie, plus evt. CompositeFrame(s) met een kopie van de relevante 'centrale' gegevens.
-Bij een 'centrale' levering: één of meer CompositeFrame(s) met de 'centrale' gegevens.
-Bij een 'voertuigen' levering: één of meer CompositeFrame(s) met de 'voertuig' gegevens.</xsd:documentation>
+					<xsd:documentation>Bij een 'dienstregeling' levering: één CompositeFrame per partitie, plus evt. CompositeFrame(s) met een kopie van de relevante 'centrale' gegevens. Bij een 'centrale' levering: één of meer CompositeFrame(s) met de 'centrale' gegevens. Bij een 'voertuigen' levering: één of meer CompositeFrame(s) met de 'voertuig' gegevens.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 		</xsd:sequence>


### PR DESCRIPTION
Geen fixed waarde "any" meer voor version-attribuut van elementen die ook in leveringen kunnen worden opgenomen (te weten Authority en TransportAdministrativeZone). Zie ook #76 