### PR TITLE
Fix #81

### DIFF
--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -1287,8 +1287,7 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 					</xsd:element>
 					<xsd:element name="VehicleAccessFacilityList">
 						<xsd:simpleType>
-							<xsd:list itemType="AccessFacilityEnumeration"/>
-							<!--	<xsd:list itemType="VehicleAccessFacilityEnumeration"/>	-->
+							<xsd:list itemType="VehicleAccessFacilityEnumeration"/>
 						</xsd:simpleType>
 					</xsd:element>
 				</xsd:sequence>


### PR DESCRIPTION
Dit sloopt de KV1-conversie die DOVA gratis weggeeft aan vervoerders.