### PR TITLE
OperatorRef in Line ter vervanging van OperatorView

### DIFF
--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -698,6 +698,7 @@ Bij een Version is attribuut 'version' verplicht. De waarde is gelijk aan attrib
 			</xsd:element>
 			<xsd:element name="ExternalLineRef" type="ExternalObjectRefStructure" minOccurs="0"/>
 			<xsd:element name="AuthorityRef" type="VersionOfObjectRefStructure" minOccurs="0"/>
+			<xsd:element name="OperatorRef" type="VersionOfObjectRefStructure"/>
 			<xsd:element name="TypeOfProductCategoryRef" type="VersionOfObjectRefStructure" minOccurs="0"/>
 			<xsd:element name="TypeOfServiceRef" type="VersionOfObjectRefStructure"/>
 			<xsd:element name="Monitored" type="xsd:boolean"/>

--- a/xsd/netex-nl.xsd
+++ b/xsd/netex-nl.xsd
@@ -29,6 +29,7 @@
 <!--                      toegevoegd t.b.v. verwijzingen naar originele route bij    -->
 <!--                      omleidingen.                                               -->
 <!--   v9.3.0  (xxx.2023) Element limitations opgenomen in accessibilityAssessment   -->
+<!--   v9.3.0  (okt.2024) OperatorView.OperatorRef vervangen door Line.OperatorRef   -->
 <!--                                                                                 -->
 <!-- Copyright:                                                                      -->
 <!--     Dit document is eigendom van Platform BISON onder Samenwerkingsverband DOVA -->
@@ -501,13 +502,6 @@
 						<xsd:complexType>
 							<xsd:sequence>
 								<xsd:element name="AvailabilityCondition" type="availabilityCondition" maxOccurs="unbounded"/>
-							</xsd:sequence>
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="OperatorView">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="OperatorRef" type="VersionOfObjectRefStructure"/>
 							</xsd:sequence>
 						</xsd:complexType>
 					</xsd:element>


### PR DESCRIPTION
De OperatorView (en daarmee de OperatorRef daarbinnen) is verwijderd en vervangen door OperatorRef binnen Line. Het idee is dat de OperatorRef van Line altijd gevuld wordt (verplicht veld) en dat deze indien nodig op ritniveau kan worden overschreven in ServiceJourney