### PR TITLE
Fix commit 7e439a4e

### DIFF
--- a/xsd/netex-nl-basic.xsd
+++ b/xsd/netex-nl-basic.xsd
@@ -174,7 +174,7 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 		</xsd:annotation>
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
-		<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified"/>
+		<xsd:attribute name="version" type="VersionIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="status" type="StatusEnumeration" use="optional" default="active" form="unqualified"/>
 	</xsd:complexType>
 	<xsd:complexType name="OrderedVersionOfObjectStructure" abstract="true">

--- a/xsd/netex-nl-basic.xsd
+++ b/xsd/netex-nl-basic.xsd
@@ -146,6 +146,16 @@
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
 		<xsd:attribute name="version" type="VersionIdType" use="required" form="unqualified"/>
 	</xsd:complexType>
+	<xsd:complexType name="DataManagedObjectStructure-any-version" abstract="true">
+		<xsd:annotation>
+			<xsd:documentation>Het object heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document.
+Het 'version' attribuut is nodig voor de constraints, maar heeft altijd de vaste waarde 'any'.
+De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
+		</xsd:annotation>
+		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
+		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
+		<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified"/>
+	</xsd:complexType>
 	<!--
 	<xsd:complexType name="DataManagedObjectStructure-modified" abstract="true">
 		<xsd:annotation>
@@ -163,9 +173,9 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 			<xsd:documentation>Een element uit een voorgedefinieerde lijst heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. De 'status' geeft aan of het element nog courant is.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
-		<xsd:attribute name="modification" type="ModificationEnumeration" default="new" form="unqualified"/>
-		<xsd:attribute name="version" type="VersionIdType" use="required" form="unqualified"/>
-		<xsd:attribute name="status" type="StatusEnumeration" default="active" form="unqualified"/>
+		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
+		<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified"/>
+		<xsd:attribute name="status" type="StatusEnumeration" use="optional" default="active" form="unqualified"/>
 	</xsd:complexType>
 	<xsd:complexType name="OrderedVersionOfObjectStructure" abstract="true">
 		<xsd:annotation>
@@ -202,7 +212,7 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 			<xsd:documentation>Een element uit een BISON standaardenumeratie heeft een uniek 'id' conform de afspraken in het NL NeTEx Profiel document. Het object heeft de vaste waarde 'any' voor attribuut 'version'. Deze waarde wordt geinterpreteerd als 'de actuele versie'.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexContent>
-			<xsd:extension base="DataManagedObjectStructure-with-version">
+			<xsd:extension base="DataManagedObjectStructure-any-version">
 				<xsd:sequence>
 					<xsd:element name="Name" type="MultilingualString"/>
 					<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -106,11 +106,6 @@
 					<xsd:element name="ShortName" type="MultilingualString"/>
 					<xsd:element name="Description" type="MultilingualString" minOccurs="0"/>
 				</xsd:sequence>
-				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
-					<xsd:annotation>
-						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -125,11 +120,6 @@
 					<xsd:element name="GroupOfLinesType" type="GroupOfLinesTypeEnumeration"/>
 					<xsd:element name="AuthorityRef" type="VersionOfObjectRefStructure"/>
 				</xsd:sequence>
-				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
-					<xsd:annotation>
-						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/xsd/netex-nl-enums.xsd
+++ b/xsd/netex-nl-enums.xsd
@@ -625,68 +625,32 @@
 	<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 	<xsd:complexType name="typeOfService">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure">
-				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
-					<xsd:annotation>
-						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:extension>
+			<xsd:extension base="TypeOfValueVersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="typeOfActivation">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure">
-				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
-					<xsd:annotation>
-						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:extension>
+			<xsd:extension base="TypeOfValueVersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="typeOfEquipment">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure">
-				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
-					<xsd:annotation>
-						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:extension>
+			<xsd:extension base="TypeOfValueVersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="typeOfResponsibilityRole">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure">
-				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
-					<xsd:annotation>
-						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:extension>
+			<xsd:extension base="TypeOfValueVersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="displayTextLength">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure">
-				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
-					<xsd:annotation>
-						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:extension>
+			<xsd:extension base="TypeOfValueVersionStructure"/>
 		</xsd:complexContent>
 	</xsd:complexType>
 	<xsd:complexType name="typeOfFrame">
 		<xsd:complexContent>
-			<xsd:extension base="TypeOfValueVersionStructure-with-version">
-				<xsd:attribute name="version" type="VersionIdType" use="required" fixed="any" form="unqualified">
-					<xsd:annotation>
-						<xsd:documentation>Het 'version' attribuut is nodig voor de constraints, maar heeft in voorgedefinieerde elementen altijd de vaste waarde 'any'. De waarde 'any' van attribuut 'version' wordt geinterpreteerd als 'de van het bovenliggende object geërfde versie'.</xsd:documentation>
-					</xsd:annotation>
-				</xsd:attribute>
-			</xsd:extension>
+			<xsd:extension base="TypeOfValueVersionStructure-with-version"/>
 		</xsd:complexContent>
 	</xsd:complexType>
 </xsd:schema>


### PR DESCRIPTION
Oorspronkelijke commit 7e439a4e: "Geen fixed waarde "any" meer voor version-attribuut van elementen die ook in leveringen kunnen worden opgenomen (te weten Authority en TransportAdministrativeZone)"

De fix bevat echter een bug waardoor de XSDs ongeldig worden. Dat is in deze PR gefixt. 