### PR TITLE
Order attributen verwijderd uit sequences

### DIFF
--- a/xsd/netex-nl-basic.xsd
+++ b/xsd/netex-nl-basic.xsd
@@ -184,7 +184,6 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
 		<xsd:attribute name="version" type="VersionIdType" default="any" form="unqualified"/>
-		<xsd:attribute name="order" type="xsd:nonNegativeInteger" use="required" form="unqualified"/>
 	</xsd:complexType>
 	<xsd:complexType name="OrderedVersionOfObjectStructure-fixed" abstract="true">
 		<xsd:annotation>
@@ -193,7 +192,6 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
 		<xsd:attribute name="version" type="VersionIdType" use="required" form="unqualified"/>
-		<xsd:attribute name="order" type="xsd:nonNegativeInteger" use="required" fixed="1" form="unqualified"/>
 	</xsd:complexType>
 	<xsd:complexType name="VersionFrameVersionStructure">
 		<xsd:annotation>

--- a/xsd/netex-nl-basic.xsd
+++ b/xsd/netex-nl-basic.xsd
@@ -184,6 +184,8 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
 		<xsd:attribute name="version" type="VersionIdType" default="any" form="unqualified"/>
+		<!-- DEPRECATED Attribuut "order" niet langer gebruiken. Volgorder wordt bepaald door positie in sequence. Optioneel gemaakt voor backwards compatibility -->
+		<xsd:attribute name="order" type="xsd:nonNegativeInteger" use="optional" form="unqualified"/>
 	</xsd:complexType>
 	<xsd:complexType name="OrderedVersionOfObjectStructure-fixed" abstract="true">
 		<xsd:annotation>
@@ -192,6 +194,8 @@ Attribuut 'modification' geeft aan of de versie voor het eerst wordt aangeleverd
 		<xsd:attribute name="id" type="ObjectIdType" use="required" form="unqualified"/>
 		<xsd:attribute name="modification" type="ModificationEnumeration" use="optional" default="new" form="unqualified"/>
 		<xsd:attribute name="version" type="VersionIdType" use="required" form="unqualified"/>
+		<!-- DEPRECATED Attribuut "order" niet langer gebruiken. Volgorder wordt bepaald door positie in sequence. Optioneel gemaakt voor backwards compatibility -->
+		<xsd:attribute name="order" type="xsd:nonNegativeInteger" use="optional" fixed="1" form="unqualified"/>
 	</xsd:complexType>
 	<xsd:complexType name="VersionFrameVersionStructure">
 		<xsd:annotation>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -644,6 +644,8 @@
 					<xsd:element name="NoticeRef" type="VersionOfObjectRefStructure"/>
 					<xsd:element name="NoticedObjectRef" type="VersionOfObjectRefStructure-with-class"/>
 				</xsd:sequence>
+				<!-- DEPRECATED Attribuut "order" niet langer gebruiken. Volgorder wordt bepaald door positie in sequence. Optioneel gemaakt voor backwards compatibility -->
+				<xsd:attribute name="order" type="xsd:nonNegativeInteger" use="optional" form="unqualified"/>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>

--- a/xsd/netex-nl-data.xsd
+++ b/xsd/netex-nl-data.xsd
@@ -644,7 +644,6 @@
 					<xsd:element name="NoticeRef" type="VersionOfObjectRefStructure"/>
 					<xsd:element name="NoticedObjectRef" type="VersionOfObjectRefStructure-with-class"/>
 				</xsd:sequence>
-				<xsd:attribute name="order" type="xsd:nonNegativeInteger" use="required" form="unqualified"/>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>


### PR DESCRIPTION
Conform het besluit in CEN. Zie ook https://github.com/NeTEx-CEN/NeTEx/issues/810