### PR TITLE
Schematron fixes

### DIFF
--- a/sch/commons/gml.sch
+++ b/sch/commons/gml.sch
@@ -1,8 +1,8 @@
 <sch:pattern id="gml" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="//gml:pos">
-        <sch:assert test=".[matches(text(),'^\d{1,6} \d{1,6}$')]">Een gml:pos moet gegeven worden als spatiegescheiden RD-coordinaten</sch:assert>
+        <sch:assert test=".[matches(text(),'^\d{1,6}(\.\d+)? \d{1,6}(\.\d+)?$')]">Een gml:pos moet gegeven worden als spatiegescheiden RD-coordinaten</sch:assert>
     </sch:rule>
     <sch:rule context="//gml:posList">
-        <sch:assert test=".[matches(text(),'^\d{1,6} \d{1,6}( \d{1,6} \d{1,6})+$')]">Een gml:posList moet gegeven worden als twee of meer spatiegescheiden RD-coordinaten</sch:assert>
+        <sch:assert test=".[matches(text(),'^\d{1,6}(\.\d+)? \d{1,6}(\.\d+)?( \d{1,6}(\.\d+)? \d{1,6}(\.\d+)?)+$')]">Een gml:posList moet gegeven worden als twee of meer spatiegescheiden RD-coordinaten</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/dienstregeling-export.sch
+++ b/sch/dienstregeling-export.sch
@@ -55,16 +55,16 @@
         </sch:rule>
     </sch:pattern>
 
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/DataSource.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/ResponsibilitySet.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/Branding.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/TypeOfProductCategory.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/Operator.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/Authority.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/OperationalContext.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/VehicleType.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/VehicleType-capacities.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/TransportAdministrativeZone.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/DataSource.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/ResponsibilitySet.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/Branding.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/TypeOfProductCategory.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/Operator.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/Authority.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/OperationalContext.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/VehicleType.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/VehicleType-capacities.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/TransportAdministrativeZone.sch"/>
 
     <!-- Validatie van de ServiceFrame -->
     <sch:pattern id="ServiceFrame">

--- a/sch/voertuigen-export.sch
+++ b/sch/voertuigen-export.sch
@@ -39,14 +39,14 @@
         </sch:rule>
     </sch:pattern>
 
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/DataSource.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/ResponsibilitySet.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/Branding.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/TypeOfProductCategory.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/Operator.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/Authority.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/OperationalContext.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/VehicleType.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/VehicleType-capacities.sch"/>
-    <sch:include href="PublicationDelivery/CompositeFrame/resourceframe/Vehicle.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/DataSource.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/ResponsibilitySet.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/Branding.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/TypeOfProductCategory.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/Operator.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/Authority.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/OperationalContext.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/VehicleType.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/VehicleType-capacities.sch"/>
+    <sch:include href="PublicationDelivery/CompositeFrame/ResourceFrame/Vehicle.sch"/>
 </sch:schema>


### PR DESCRIPTION
Verder nadenken over:
 - het niet beschikbaar zijn van ServiceCalendarFrame en VehicleScheduledFrame
 - of we nog een check willen dat de coordinaten **maximaal** in centimeters worden opgegeven
 - in de documentatie is er een suggestie dat constraint validatie wordt gedaan binnen deze schematron validatie, dat is **niet** het geval
 - nadenken over: wanneer elementen naar **bekende** externe enumeraties verwijzen zoals NL:DOVA zou mijn suggestie zijn in een nieuwe NeTEx versie afspraken te maken over; indien deze elementen worden meegeleverd geen version"**any**" te gebruiken maar te verwijzen naar meegeleverde versie, indien de enumeraties niet worden meegeleverd versionRef="**any**" te gebruiken.