### PR TITLE
Fix structural errors in Schematron validation files

### DIFF
--- a/sch/CDSP/GeneralFrame/TypeOfFrameRef.sch
+++ b/sch/CDSP/GeneralFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref='BISON:TypeOfFrame:NL_TT_BASELINE'.</sch:assert>
-        <sch:assert test="normalize-space(@version)='9.3.0'">TypeOfFrameRef must have version='9.3.0'.</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref='NL:BISON:TypeOfFrame:NL_TT_BASELINE'.</sch:assert>
+        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version='9.4.0'.</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/Algemeen/Presentation.sch
+++ b/sch/DRG/Algemeen/Presentation.sch
@@ -3,8 +3,8 @@
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->
-        <sch:assert test="matches(normalize-space(ntx:Presentation/ntx:Colour), '^[0-9A-Fa-f]{6}$')">Colour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
-        <sch:assert test="matches(normalize-space(ntx:Presentation/ntx:TextColour), '^[0-9A-Fa-f]{6}$')">TextColour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
+        <sch:assert test="not(ntx:Presentation/ntx:Colour) or matches(normalize-space(ntx:Presentation/ntx:Colour), '^[0-9A-Fa-f]{6}$')">Colour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
+        <sch:assert test="not(ntx:Presentation/ntx:TextColour) or matches(normalize-space(ntx:Presentation/ntx:TextColour), '^[0-9A-Fa-f]{6}$')">TextColour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
 
         <!-- Other business rules -->
     </sch:rule>

--- a/sch/DRG/Algemeen/Presentation.sch
+++ b/sch/DRG/Algemeen/Presentation.sch
@@ -3,8 +3,8 @@
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->
-        <sch:assert test="matches(normalize-space(/ntx:Presentation/ntx:Colour), '[0-9A-Fa-f]{6}')">Colour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
-        <sch:assert test="matches(normalize-space(/ntx:Presentation/ntx:TextColour), '[0-9A-Fa-f]{6}')">TextColour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:Presentation/ntx:Colour), '^[0-9A-Fa-f]{6}$')">Colour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:Presentation/ntx:TextColour), '^[0-9A-Fa-f]{6}$')">TextColour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
 
         <!-- Other business rules -->
     </sch:rule>

--- a/sch/DRG/CompositeFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/CompositeFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/GML/posList.sch
+++ b/sch/DRG/GML/posList.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.gml.posList" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="//gml:posList">
-        <sch:assert test=".[matches(text(),'^^-?(90|[0-8]?\d)(\.\d+)? +-?(180|1[0-7]\d|\d?\d)(\.\d+)?$( +^-?(90|[0-8]?\d)(\.\d+)? +-?(180|1[0-7]\d|\d?\d)(\.\d+)?$)+$')]">Een gml:posList moet gegeven worden als twee of meer spatiegescheiden WGS84-coordinaten</sch:assert>
+        <sch:assert test=".[matches(text(),'^-?(90|[0-8]?\d)(\.\d+)? +-?(180|1[0-7]\d|\d?\d)(\.\d+)?( +-?(90|[0-8]?\d)(\.\d+)? +-?(180|1[0-7]\d|\d?\d)(\.\d+)?)+$')]">Een gml:posList moet gegeven worden als twee of meer spatiegescheiden WGS84-coordinaten</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/InfrastructureFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/InfrastructureFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.InfrastructureFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ResourceFrame/OperationalContext.sch
+++ b/sch/DRG/ResourceFrame/OperationalContext.sch
@@ -8,15 +8,15 @@
         <!-- Other business rules -->
 
         <!-- A -->
-        <sch:assert test="normalize-space(/ntx:VehicleMode)=('unknown','all','bus','metro','tram','rail','water')">Het NL-profiel ondersteunt alleen de volgende waardes voor VehicleMode: unknown | all | bus | metro | tram | rail | water</sch:assert>
+        <sch:assert test="normalize-space(ntx:VehicleMode)=('unknown','all','bus','metro','tram','rail','water')">Het NL-profiel ondersteunt alleen de volgende waardes voor VehicleMode: unknown | all | bus | metro | tram | rail | water</sch:assert>
 
         <!-- B -->
-        <sch:assert test="(normalize-space(/ntx:VehicleMode)=('unknown','all','bus','metro','tram','rail','water') and not(/ntx:TransportSubMode)) or
-                          (normalize-space(/ntx:VehicleMode)='bus' and normalize-space(/ntx:TransportSubMode)=('localBus','regionalBus','expressBus','nightBus','mobilityBus','shuttleBus','highFrequencyBus','schoolBus','schoolAndPublicServiceBus','railReplacementBus','demandAndResponseBus','unknown','undefined')) or
-                          (normalize-space(/ntx:VehicleMode)='metro' and normalize-space(/ntx:TransportSubMode)=('metro','urbanRailway','unknown','undefined')) or
-                          (normalize-space(/ntx:VehicleMode)='tram' and normalize-space(/ntx:TransportSubMode)=('cityTram','localTram','regionalTram','trainTram','unknown','undefined')) or
-                          (normalize-space(/ntx:VehicleMode)='rail' and normalize-space(/ntx:TransportSubMode)=('local','highSpeedRail','suburbanRailway','regionalRail','longDistance','international','specialTrain','unknown','undefined')) or
-                          (normalize-space(/ntx:VehicleMode)='water' and normalize-space(/ntx:TransportSubMode)=('localCarFerry','localPassengerFerry','riverBus','unknown','undefined'))
+        <sch:assert test="(normalize-space(ntx:VehicleMode)=('unknown','all','bus','metro','tram','rail','water') and not(ntx:TransportSubMode)) or
+                          (normalize-space(ntx:VehicleMode)='bus' and normalize-space(ntx:TransportSubMode)=('localBus','regionalBus','expressBus','nightBus','mobilityBus','shuttleBus','highFrequencyBus','schoolBus','schoolAndPublicServiceBus','railReplacementBus','demandAndResponseBus','unknown','undefined')) or
+                          (normalize-space(ntx:VehicleMode)='metro' and normalize-space(ntx:TransportSubMode)=('metro','urbanRailway','unknown','undefined')) or
+                          (normalize-space(ntx:VehicleMode)='tram' and normalize-space(ntx:TransportSubMode)=('cityTram','localTram','regionalTram','trainTram','unknown','undefined')) or
+                          (normalize-space(ntx:VehicleMode)='rail' and normalize-space(ntx:TransportSubMode)=('local','highSpeedRail','suburbanRailway','regionalRail','longDistance','international','specialTrain','unknown','undefined')) or
+                          (normalize-space(ntx:VehicleMode)='water' and normalize-space(ntx:TransportSubMode)=('localCarFerry','localPassengerFerry','riverBus','unknown','undefined'))
 ">De TransportSubMode matcht niet bij de opgegeven VehicleMode</sch:assert>
 
     </sch:rule>

--- a/sch/DRG/ResourceFrame/PassengerCapacity.sch
+++ b/sch/DRG/ResourceFrame/PassengerCapacity.sch
@@ -1,20 +1,17 @@
-<sch:pattern id="DRG.ResourceFrame.OperationalContext" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:OperationalContext">
+<sch:pattern id="DRG.ResourceFrame.PassengerCapacity" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:vehicleTypes/ntx:VehicleType/ntx:capacities/ntx:PassengerCapacity">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->
-        <sch:assert test="ntx:Name/text()!=''">Name is verplicht</sch:assert>
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="matches(normalize-space(/ntx:VehicleMode), [petrol|diesel|naturalGas|biodiesel|electricity|hydrogen|other])">
-            Het NL-profiel ondersteunt alleen de volgende waardes voor FuelType: petrol | diesel | naturalGas | biodiesel | electricity | hydrogen | other
-        </sch:assert>
+        <!-- TODO: Original rule incorrectly validated VehicleMode against FuelType values - needs review -->
 
         <!-- B -->
-        <assert test="number(normalize-space(ntx:TotalCapacity)) = number(normalize-space(ntx:SeatingCapacity)) + number(normalize-space(ntx:StandingCapacity))">
+        <sch:assert test="number(normalize-space(ntx:TotalCapacity)) = number(normalize-space(ntx:SeatingCapacity)) + number(normalize-space(ntx:StandingCapacity))">
             TotalCapacity moet gelijk zijn aan SeatingCapacity plus StandingCapacity
-        </assert>
+        </sch:assert>
 
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ResourceFrame/ServiceFacilitySet.sch
+++ b/sch/DRG/ResourceFrame/ServiceFacilitySet.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="DRG.ResourceFrame.OperationalContext" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+<sch:pattern id="DRG.ResourceFrame.ServiceFacilitySet" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:ServiceFacilitySet">
         <!-- Variables for use in business rule -->
 
@@ -6,15 +6,15 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="matches(normalize-space(/ntx:PassengerCommsFacilityList), '[powerSupplySockets|freeWif]')">Het NL-profiel ondersteunt alleen de volgende waardes voor PassengerCommsFacilityList: powerSupplySockets | freeWif</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:PassengerCommsFacilityList), '^(powerSupplySockets|freeWifi)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor PassengerCommsFacilityList: powerSupplySockets | freeWifi</sch:assert>
 
         <!-- B -->
-        <sch:assert test="matches(normalize-space(/ntx:SanitaryFacilityList), '[toilet|wheelchairAccessToilet]')">Het NL-profiel ondersteunt alleen de volgende waardes voor SanitaryFacilityList: toilet | wheelchairAccessToilet</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:SanitaryFacilityList), '^(toilet|wheelchairAccessToilet)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor SanitaryFacilityList: toilet | wheelchairAccessToilet</sch:assert>
 
         <!-- C -->
-        <sch:assert test="matches(normalize-space(/ntx:TicketingServiceFacilityList), '[collection]')">Het NL-profiel ondersteunt alleen de volgende waardes voor TicketingServiceFacilityList: collection</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:TicketingServiceFacilityList), '^(collection)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor TicketingServiceFacilityList: collection</sch:assert>
 
         <!-- D -->
-        <sch:assert test="matches(normalize-space(/ntx:VehicleAccessFacilityList), '[wheelchairLift|manualRamp|automaticRamp|steps|slidingStep|narrowEntrance|validator]')">Het NL-profiel ondersteunt alleen de volgende waardes voor VehicleAccessFacilityList: wheelchairLift | manualRamp | automaticRamp | steps | slidingStep | narrowEntrance | validator</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:VehicleAccessFacilityList), '^(wheelchairLift|manualRamp|automaticRamp|steps|slidingStep|narrowEntrance|validator)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor VehicleAccessFacilityList: wheelchairLift | manualRamp | automaticRamp | steps | slidingStep | narrowEntrance | validator</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ResourceFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/ResourceFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.ResourceFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_BASELINE']/ntx:frames/ntx:ResourceFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_RESOURCE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_RESOURCE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_RESOURCE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_RESOURCE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ResourceFrame/VehicleType.sch
+++ b/sch/DRG/ResourceFrame/VehicleType.sch
@@ -14,9 +14,9 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="matches(normalize-space(/ntx:FuelType), '[petrol|diesel|naturalGas|biodiesel|electricity|hydrogen|other]')">Het NL-profiel ondersteunt alleen de volgende waardes voor FuelType: petrol | diesel | naturalGas | biodiesel | electricity | hydrogen | other</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:FuelType), '^(petrol|diesel|naturalGas|biodiesel|electricity|hydrogen|other)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor FuelType: petrol | diesel | naturalGas | biodiesel | electricity | hydrogen | other</sch:assert>
 
         <!-- B -->
-        <sch:assert test="/ntx:capacities[count(ntx:PassengerCapacity)=1] or /ntx:capacities[count(ntx:PassengerCapacityRef)=1]">Altijd 1 embedded PassengerCapacity element OF 1 PassengerCapacityRef verwijzing opnemen</sch:assert>
+        <sch:assert test="ntx:capacities[count(ntx:PassengerCapacity)=1] or ntx:capacities[count(ntx:PassengerCapacityRef)=1]">Altijd 1 embedded PassengerCapacity element OF 1 PassengerCapacityRef verwijzing opnemen</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceCalendarFrame/DayTypeAssignment.sch
+++ b/sch/DRG/ServiceCalendarFrame/DayTypeAssignment.sch
@@ -3,8 +3,6 @@
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->
-        <sch:assert test="ntx:Date">Date is verplicht</sch:assert>
-        <sch:assert test="ntx:DayTypeRef">DayTypeRef is verplicht</sch:assert>
 
         <!-- Other business rules -->
     </sch:rule>

--- a/sch/DRG/ServiceCalendarFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/ServiceCalendarFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/PassengerStopAssignment.sch
+++ b/sch/DRG/ServiceFrame/PassengerStopAssignment.sch
@@ -7,8 +7,6 @@
         <sch:assert test="ntx:QuayRef">QuayRef is verplicht</sch:assert>
 
         <!-- Other business rules -->
-        <!-- A -->
-        <sch:assert test="ntx:QuayRef">QuayRef is verplicht</sch:assert>
 
         <!-- B -->
         <!-- TODO Elke ScheduledStopPoint dient exact één keer voor te komen in de lijst met PassengerStopAssignments.-->

--- a/sch/DRG/ServiceFrame/Route.sch
+++ b/sch/DRG/ServiceFrame/Route.sch
@@ -9,7 +9,7 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="count(ntx:PointOnRoute)>1">Er wordt een minimum van twee PointOnRoute elementen verwacht</sch:assert>
+        <sch:assert test="count(ntx:pointsInSequence/ntx:PointOnRoute)>1">Er wordt een minimum van twee PointOnRoute elementen verwacht</sch:assert>
 
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/ServiceJourneyPattern.sch
+++ b/sch/DRG/ServiceFrame/ServiceJourneyPattern.sch
@@ -8,7 +8,5 @@
         <sch:assert test="ntx:pointsInSequence[count(*)>1]">Er moeten minimaal twee punten opgenomen zijn in de pointsInSequence (StopPointInJourneyPattern en/of TimingPointInJourneyPattern)</sch:assert>
 
         <!-- Other business rules -->
-        <!-- A -->
-        <sch:assert test="ntx:pointsInSequence[count(*)>1]">Er moeten minimaal twee punten opgenomen zijn in de pointsInSequence (StopPointInJourneyPattern en/of TimingPointInJourneyPattern)</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/StopArea.sch
+++ b/sch/DRG/ServiceFrame/StopArea.sch
@@ -7,6 +7,6 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="ntx:privateCodes/ntx:PrivateCode[@type='UserStopAreaCode']/text()=''">De waarde van de PrivateCode van type 'UserStopAreaCode' mag niet leeg zijn</sch:assert>
+        <sch:assert test="ntx:privateCodes/ntx:PrivateCode[@type='UserStopAreaCode']/text()!=''">De waarde van de PrivateCode van type 'UserStopAreaCode' mag niet leeg zijn</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/TimingPoint.sch
+++ b/sch/DRG/ServiceFrame/TimingPoint.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="DRG.ServiceFrame.TimingPoint" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="DRG.ServiceFrame.TimingPoint" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:timingPoints/ntx:TimingPoint">
         <!-- Variables for use in business rule -->
 
@@ -9,7 +9,7 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="ntx:privateCodes/ntx:PrivateCode[@type='UserStopCode']/text()=''">De waarde van de PrivateCode van type 'UserStopCode' mag niet leeg zijn</sch:assert>
+        <sch:assert test="ntx:privateCodes/ntx:PrivateCode[@type='UserStopCode']/text()!=''">De waarde van de PrivateCode van type 'UserStopCode' mag niet leeg zijn</sch:assert>
 
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/ServiceFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/TimetableFrame/AvailabilityCondition.sch
+++ b/sch/DRG/TimetableFrame/AvailabilityCondition.sch
@@ -1,10 +1,10 @@
-<sch:pattern id="DRG.TimetableFrame.AvailabilityCondition" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="DRG.TimetableFrame.AvailabilityCondition" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:contentValidityConditions/ntx:AvailabilityCondition">
         <!-- Variables for use in business rule -->
-        <let name="from" value="xs:date(ntx:FromDate)"/>
-        <let name="to" value="xs:date(ntx:ToDate)"/>
-        <let name="bits" value="replace(normalize-space(ntx:ValidDayBits), '\s+', '')"/>
-        <let name="daysInclusive" value="floor(( $to - $from ) div xs:dayTimeDuration('P1D')) + 1"/>
+        <sch:let name="from" value="xs:date(ntx:FromDate)"/>
+        <sch:let name="to" value="xs:date(ntx:ToDate)"/>
+        <sch:let name="bits" value="replace(normalize-space(ntx:ValidDayBits), '\s+', '')"/>
+        <sch:let name="daysInclusive" value="floor(( $to - $from ) div xs:dayTimeDuration('P1D')) + 1"/>
 
         <!-- Cardinality and data-type constraints -->
         <sch:assert test="ntx:FromDate">FromDate is verplicht</sch:assert>
@@ -16,9 +16,9 @@
         <!-- De ToDate van de AvailabilityCondition dient ná de FromDate te liggen óf hieraan gelijk te zijn. -->
 
         <!-- B -->
-        <assert test="string-length($bits)=$daysInclusive">
-            Lengte van ValidDayBits (<value-of select="string-length($bits)"/>) moet gelijk zijn aan het aantal dagen tussen FromDate en ToDate (inclusief) (<value-of select="$daysInclusive"/>).
-        </assert>
+        <sch:assert test="string-length($bits)=$daysInclusive">
+            Lengte van ValidDayBits (<sch:value-of select="string-length($bits)"/>) moet gelijk zijn aan het aantal dagen tussen FromDate en ToDate (inclusief) (<sch:value-of select="$daysInclusive"/>).
+        </sch:assert>
 
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/TimetableFrame/AvailabilityCondition.sch
+++ b/sch/DRG/TimetableFrame/AvailabilityCondition.sch
@@ -1,8 +1,8 @@
 <sch:pattern id="DRG.TimetableFrame.AvailabilityCondition" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:contentValidityConditions/ntx:AvailabilityCondition">
         <!-- Variables for use in business rule -->
-        <sch:let name="from" value="xs:date(ntx:FromDate)"/>
-        <sch:let name="to" value="xs:date(ntx:ToDate)"/>
+        <sch:let name="from" value="xs:dateTime(ntx:FromDate)"/>
+        <sch:let name="to" value="xs:dateTime(ntx:ToDate)"/>
         <sch:let name="bits" value="replace(normalize-space(ntx:ValidDayBits), '\s+', '')"/>
         <sch:let name="daysInclusive" value="floor(( $to - $from ) div xs:dayTimeDuration('P1D')) + 1"/>
 

--- a/sch/DRG/TimetableFrame/DeadRun.sch
+++ b/sch/DRG/TimetableFrame/DeadRun.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="DRG.TimetableFrame.DeadRun" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="DRG.TimetableFrame.DeadRun" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:vehicleJourneys/ntx:DeadRun">
         <!-- Variables for use in business rule -->
 

--- a/sch/DRG/TimetableFrame/ServiceJourney.sch
+++ b/sch/DRG/TimetableFrame/ServiceJourney.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="DRG.TimetableFrame.ServiceJourney" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="DRG.TimetableFrame.ServiceJourney" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:vehicleJourneys/ntx:ServiceJourney">
         <!-- Variables for use in business rule -->
 

--- a/sch/DRG/TimetableFrame/ServiceJourneyInterchange.sch
+++ b/sch/DRG/TimetableFrame/ServiceJourneyInterchange.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="TimetableFrame-ServiceJourneyInterchange" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="TimetableFrame-ServiceJourneyInterchange" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:journeyInterchanges/ntx:ServiceJourneyInterchange">
         <!-- Variables for use in business rule -->
 

--- a/sch/DRG/TimetableFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/TimetableFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/VehicleScheduleFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/VehicleScheduleFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/dienstregeling-export.sch
+++ b/sch/DRG/dienstregeling-export.sch
@@ -95,7 +95,7 @@
 
     <sch:pattern>
         <sch:rule context="ntx:PublicationDelivery">
-            <sch:assert test="PublicationTimestamp">PublicationTimestamp is verplicht</sch:assert>
+            <sch:assert test="ntx:PublicationTimestamp">PublicationTimestamp is verplicht</sch:assert>
         </sch:rule>
     </sch:pattern>
 </sch:schema>


### PR DESCRIPTION
- Fix regex in matches(): replace character classes with proper alternation groups using parentheses and anchors
- Fix absolute XPaths /ntx: to relative ntx:
- Add missing sch: namespace prefix on let, assert, value-of elements
- Fix inverted test logic: ='' to !='' where message says must not be empty
- Remove stray extra > after sch:pattern opening tags
- Fix duplicate pattern IDs for ServiceFacilitySet and PassengerCapacity
- Rewrite PassengerCapacity.sch: fix rule context, remove wrong validation
- Remove duplicate assertions
- Fix malformed regex in posList.sch
- Fix typo freeWif to freeWifi
- Remove redundant xmlns:sch on individual assert
- Add anchors to hex colour regex in Presentation.sch