### PR TITLE
Feature/schematron based on extension

### DIFF
--- a/sch/CDSP/GeneralFrame/TypeOfFrameRef.sch
+++ b/sch/CDSP/GeneralFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref='BISON:TypeOfFrame:NL_TT_BASELINE'.</sch:assert>
-        <sch:assert test="normalize-space(@version)='9.3.0'">TypeOfFrameRef must have version='9.3.0'.</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref='NL:BISON:TypeOfFrame:NL_TT_BASELINE'.</sch:assert>
+        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version='9.4.0'.</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/Algemeen/Presentation.sch
+++ b/sch/DRG/Algemeen/Presentation.sch
@@ -3,8 +3,8 @@
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->
-        <sch:assert test="matches(normalize-space(ntx:Presentation/ntx:Colour), '^[0-9A-Fa-f]{6}$')">Colour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
-        <sch:assert test="matches(normalize-space(ntx:Presentation/ntx:TextColour), '^[0-9A-Fa-f]{6}$')">TextColour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
+        <sch:assert test="not(ntx:Presentation/ntx:Colour) or matches(normalize-space(ntx:Presentation/ntx:Colour), '^[0-9A-Fa-f]{6}$')">Colour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
+        <sch:assert test="not(ntx:Presentation/ntx:TextColour) or matches(normalize-space(ntx:Presentation/ntx:TextColour), '^[0-9A-Fa-f]{6}$')">TextColour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
 
         <!-- Other business rules -->
     </sch:rule>

--- a/sch/DRG/Algemeen/Presentation.sch
+++ b/sch/DRG/Algemeen/Presentation.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.Algemeen.Presentation.A" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/Algemeen/Presentation.sch
+++ b/sch/DRG/Algemeen/Presentation.sch
@@ -3,8 +3,8 @@
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->
-        <sch:assert test="matches(normalize-space(/ntx:Presentation/ntx:Colour), '[0-9A-Fa-f]{6}')">Colour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
-        <sch:assert test="matches(normalize-space(/ntx:Presentation/ntx:TextColour), '[0-9A-Fa-f]{6}')">TextColour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:Presentation/ntx:Colour), '^[0-9A-Fa-f]{6}$')">Colour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:Presentation/ntx:TextColour), '^[0-9A-Fa-f]{6}$')">TextColour moet een RGB-kleur (hexadecimale string van 6 karakters) zijn</sch:assert>
 
         <!-- Other business rules -->
     </sch:rule>

--- a/sch/DRG/CompositeFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/CompositeFrame/TypeOfFrameRef.sch
@@ -1,6 +1,0 @@
-<sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
-        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
-    </sch:rule>
-</sch:pattern>

--- a/sch/DRG/CompositeFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/CompositeFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/CompositeFrame/frames.sch
+++ b/sch/DRG/CompositeFrame/frames.sch
@@ -1,10 +1,13 @@
+<!-- Profile selection migrated from TypeOfFrameRef to Extensions/ProfileMarker.
+     Frame composition rules now check for the presence of the correct frame element types,
+     not for TypeOfFrameRef values on child frames. -->
 <sch:pattern id="DRG.CompositeFrame.frames" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:CompositeFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_BASELINE']/ntx:frames">
-        <sch:assert test="ntx:ResourceFrame/ntx:TypeOfFrameRef[count(@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE')=1]">Er moet exact 1 ResourceFrame (van type 'NL:BISON:TypeOfFrame:NL_TT_RESOURCE') worden geleverd als onderdeel van de dienstregeling</sch:assert>
-        <sch:assert test="not(ntx:InfrastructureFrame) or ntx:InfrastructureFrame/ntx:TypeOfFrameRef[count(@ref='NL:BISON:TypeOfFrame:NL_TT_INFRA')&lt;2]">Er moet 0 of 1 InfrastructureFrames (van type 'NL:BISON:TypeOfFrame:NL_TT_INFRA') worden geleverd als onderdeel van de dienstregeling</sch:assert>
-        <sch:assert test="ntx:ServiceFrame/ntx:TypeOfFrameRef[count(@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE')=1]">Er moet exact 1 ServiceFrame (van type 'NL:BISON:TypeOfFrame:NL_TT_SERVICE') worden geleverd als onderdeel van de dienstregeling</sch:assert>
-        <sch:assert test="ntx:TimetableFrame/ntx:TypeOfFrameRef[count(@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE')&gt;0]">Er moet minimaal 1 TimetableFrame (van type 'NL:BISON:TypeOfFrame:NL_TT_TIMETABLE') worden geleverd als onderdeel van de dienstregeling</sch:assert>
-        <sch:assert test="ntx:ServiceCalendarFrame/ntx:TypeOfFrameRef[count(@ref='NL:BISON:TypeOfFrame:NL_TT_CALENDAR')=1]">Er moet exact 1 ServiceCalendarFrame (van type 'NL:BISON:TypeOfFrame:NL_TT_CALENDAR') worden geleverd als onderdeel van de dienstregeling</sch:assert>
-        <sch:assert test="ntx:VehicleScheduleFrame/ntx:TypeOfFrameRef[count(@ref='NL:BISON:TypeOfFrame:NL_TT_VEHICLE')=1]">Er moet exact 1 VehicleScheduleFrame (van type 'NL:BISON:TypeOfFrame:NL_TT_VEHICLE') worden geleverd als onderdeel van de dienstregeling</sch:assert>
+    <sch:rule context="ntx:CompositeFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:frames">
+        <sch:assert test="count(ntx:ResourceFrame)=1">Er moet exact 1 ResourceFrame worden geleverd als onderdeel van de dienstregeling</sch:assert>
+        <sch:assert test="count(ntx:InfrastructureFrame) &lt; 2">Er moet 0 of 1 InfrastructureFrames worden geleverd als onderdeel van de dienstregeling</sch:assert>
+        <sch:assert test="count(ntx:ServiceFrame)=1">Er moet exact 1 ServiceFrame worden geleverd als onderdeel van de dienstregeling</sch:assert>
+        <sch:assert test="count(ntx:TimetableFrame) &gt; 0">Er moet minimaal 1 TimetableFrame worden geleverd als onderdeel van de dienstregeling</sch:assert>
+        <sch:assert test="count(ntx:ServiceCalendarFrame)=1">Er moet exact 1 ServiceCalendarFrame worden geleverd als onderdeel van de dienstregeling</sch:assert>
+        <sch:assert test="count(ntx:VehicleScheduleFrame)=1">Er moet exact 1 VehicleScheduleFrame worden geleverd als onderdeel van de dienstregeling</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/GML/posList.sch
+++ b/sch/DRG/GML/posList.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.gml.posList" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="//gml:posList">
-        <sch:assert test=".[matches(text(),'^^-?(90|[0-8]?\d)(\.\d+)? +-?(180|1[0-7]\d|\d?\d)(\.\d+)?$( +^-?(90|[0-8]?\d)(\.\d+)? +-?(180|1[0-7]\d|\d?\d)(\.\d+)?$)+$')]">Een gml:posList moet gegeven worden als twee of meer spatiegescheiden WGS84-coordinaten</sch:assert>
+        <sch:assert test=".[matches(text(),'^-?(90|[0-8]?\d)(\.\d+)? +-?(180|1[0-7]\d|\d?\d)(\.\d+)?( +-?(90|[0-8]?\d)(\.\d+)? +-?(180|1[0-7]\d|\d?\d)(\.\d+)?)+$')]">Een gml:posList moet gegeven worden als twee of meer spatiegescheiden WGS84-coordinaten</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/InfrastructureFrame/ActivationPoint.sch
+++ b/sch/DRG/InfrastructureFrame/ActivationPoint.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.InfrastructureFrame.ActivationPoint" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:InfrastructureFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_INFRA']/ntx:activationPoints/ntx:ActivationPoint">
+    <sch:rule context="ntx:InfrastructureFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:activationPoints/ntx:ActivationPoint">
 
         <!-- Cardinality and data-type constraints -->
         <sch:assert test="ntx:TypeOfActivationRef">TypeOfActivationRef is verplicht</sch:assert>

--- a/sch/DRG/InfrastructureFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/InfrastructureFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.InfrastructureFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/InfrastructureFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/InfrastructureFrame/TypeOfFrameRef.sch
@@ -1,6 +1,0 @@
-<sch:pattern id="DRG.InfrastructureFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
-        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
-    </sch:rule>
-</sch:pattern>

--- a/sch/DRG/ProfileMarker.sch
+++ b/sch/DRG/ProfileMarker.sch
@@ -1,0 +1,23 @@
+<!-- Profile selection is based on Extensions/ProfileMarker (urn:bison:profile namespace),
+     not on TypeOfFrameRef. This pattern validates that each frame in the NL BISON timetable
+     profile carries a correct local profile marker. -->
+<sch:pattern id="DRG.ProfileMarker" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+
+    <!-- CompositeFrame must carry the NL-BISON-TIMETABLE profile marker -->
+    <sch:rule context="ntx:CompositeFrame">
+        <sch:assert test="ntx:Extensions/bpf:ProfileMarker/bpf:ProfileCode='NL-BISON-TIMETABLE'">CompositeFrame moet een Extensions/ProfileMarker bevatten met ProfileCode 'NL-BISON-TIMETABLE' (urn:bison:profile namespace).</sch:assert>
+        <sch:assert test="ntx:Extensions/bpf:ProfileMarker/bpf:ProfileVersion='9.4.0'">CompositeFrame moet een Extensions/ProfileMarker bevatten met ProfileVersion '9.4.0'.</sch:assert>
+    </sch:rule>
+
+    <!-- Each child frame inside a profiled CompositeFrame must also carry the profile marker -->
+    <sch:rule context="ntx:CompositeFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:frames/ntx:ResourceFrame |
+                       ntx:CompositeFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:frames/ntx:ServiceCalendarFrame |
+                       ntx:CompositeFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:frames/ntx:ServiceFrame |
+                       ntx:CompositeFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:frames/ntx:TimetableFrame |
+                       ntx:CompositeFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:frames/ntx:InfrastructureFrame |
+                       ntx:CompositeFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:frames/ntx:VehicleScheduleFrame">
+        <sch:assert test="ntx:Extensions/bpf:ProfileMarker/bpf:ProfileCode='NL-BISON-TIMETABLE'">Elk frame binnen een NL-BISON-TIMETABLE CompositeFrame moet een Extensions/ProfileMarker bevatten met ProfileCode 'NL-BISON-TIMETABLE'.</sch:assert>
+        <sch:assert test="ntx:Extensions/bpf:ProfileMarker/bpf:ProfileVersion='9.4.0'">Elk frame binnen een NL-BISON-TIMETABLE CompositeFrame moet een Extensions/ProfileMarker bevatten met ProfileVersion '9.4.0'.</sch:assert>
+    </sch:rule>
+
+</sch:pattern>

--- a/sch/DRG/ResourceFrame/Authority.sch
+++ b/sch/DRG/ResourceFrame/Authority.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.Authority" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:organisations/ntx:Authority">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:organisations/ntx:Authority">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/Branding.sch
+++ b/sch/DRG/ResourceFrame/Branding.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.Branding" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:typesOfValue/ntx:Branding">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:typesOfValue/ntx:Branding">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/DataSource.sch
+++ b/sch/DRG/ResourceFrame/DataSource.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.DataSource" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:dataSources/ntx:DataSource">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:dataSources/ntx:DataSource">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/OperationalContext.sch
+++ b/sch/DRG/ResourceFrame/OperationalContext.sch
@@ -8,15 +8,15 @@
         <!-- Other business rules -->
 
         <!-- A -->
-        <sch:assert test="normalize-space(/ntx:VehicleMode)=('unknown','all','bus','metro','tram','rail','water')">Het NL-profiel ondersteunt alleen de volgende waardes voor VehicleMode: unknown | all | bus | metro | tram | rail | water</sch:assert>
+        <sch:assert test="normalize-space(ntx:VehicleMode)=('unknown','all','bus','metro','tram','rail','water')">Het NL-profiel ondersteunt alleen de volgende waardes voor VehicleMode: unknown | all | bus | metro | tram | rail | water</sch:assert>
 
         <!-- B -->
-        <sch:assert test="(normalize-space(/ntx:VehicleMode)=('unknown','all','bus','metro','tram','rail','water') and not(/ntx:TransportSubMode)) or
-                          (normalize-space(/ntx:VehicleMode)='bus' and normalize-space(/ntx:TransportSubMode)=('localBus','regionalBus','expressBus','nightBus','mobilityBus','shuttleBus','highFrequencyBus','schoolBus','schoolAndPublicServiceBus','railReplacementBus','demandAndResponseBus','unknown','undefined')) or
-                          (normalize-space(/ntx:VehicleMode)='metro' and normalize-space(/ntx:TransportSubMode)=('metro','urbanRailway','unknown','undefined')) or
-                          (normalize-space(/ntx:VehicleMode)='tram' and normalize-space(/ntx:TransportSubMode)=('cityTram','localTram','regionalTram','trainTram','unknown','undefined')) or
-                          (normalize-space(/ntx:VehicleMode)='rail' and normalize-space(/ntx:TransportSubMode)=('local','highSpeedRail','suburbanRailway','regionalRail','longDistance','international','specialTrain','unknown','undefined')) or
-                          (normalize-space(/ntx:VehicleMode)='water' and normalize-space(/ntx:TransportSubMode)=('localCarFerry','localPassengerFerry','riverBus','unknown','undefined'))
+        <sch:assert test="(normalize-space(ntx:VehicleMode)=('unknown','all','bus','metro','tram','rail','water') and not(ntx:TransportSubMode)) or
+                          (normalize-space(ntx:VehicleMode)='bus' and normalize-space(ntx:TransportSubMode)=('localBus','regionalBus','expressBus','nightBus','mobilityBus','shuttleBus','highFrequencyBus','schoolBus','schoolAndPublicServiceBus','railReplacementBus','demandAndResponseBus','unknown','undefined')) or
+                          (normalize-space(ntx:VehicleMode)='metro' and normalize-space(ntx:TransportSubMode)=('metro','urbanRailway','unknown','undefined')) or
+                          (normalize-space(ntx:VehicleMode)='tram' and normalize-space(ntx:TransportSubMode)=('cityTram','localTram','regionalTram','trainTram','unknown','undefined')) or
+                          (normalize-space(ntx:VehicleMode)='rail' and normalize-space(ntx:TransportSubMode)=('local','highSpeedRail','suburbanRailway','regionalRail','longDistance','international','specialTrain','unknown','undefined')) or
+                          (normalize-space(ntx:VehicleMode)='water' and normalize-space(ntx:TransportSubMode)=('localCarFerry','localPassengerFerry','riverBus','unknown','undefined'))
 ">De TransportSubMode matcht niet bij de opgegeven VehicleMode</sch:assert>
 
     </sch:rule>

--- a/sch/DRG/ResourceFrame/OperationalContext.sch
+++ b/sch/DRG/ResourceFrame/OperationalContext.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.OperationalContext" xmlns:sch="http://purl.oclc.org/dsdl/schematron" >
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:operationalContexts/ntx:OperationalContext">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:operationalContexts/ntx:OperationalContext">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/Operator.sch
+++ b/sch/DRG/ResourceFrame/Operator.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.Operator" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:organisations/ntx:Operator">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:organisations/ntx:Operator">
     <!-- Variables for use in business rule -->
 
     <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/PassengerCapacity.sch
+++ b/sch/DRG/ResourceFrame/PassengerCapacity.sch
@@ -1,20 +1,17 @@
-<sch:pattern id="DRG.ResourceFrame.OperationalContext" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:OperationalContext">
+<sch:pattern id="DRG.ResourceFrame.PassengerCapacity" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:vehicleTypes/ntx:VehicleType/ntx:capacities/ntx:PassengerCapacity">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->
-        <sch:assert test="ntx:Name/text()!=''">Name is verplicht</sch:assert>
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="matches(normalize-space(/ntx:VehicleMode), [petrol|diesel|naturalGas|biodiesel|electricity|hydrogen|other])">
-            Het NL-profiel ondersteunt alleen de volgende waardes voor FuelType: petrol | diesel | naturalGas | biodiesel | electricity | hydrogen | other
-        </sch:assert>
+        <!-- TODO: Original rule incorrectly validated VehicleMode against FuelType values - needs review -->
 
         <!-- B -->
-        <assert test="number(normalize-space(ntx:TotalCapacity)) = number(normalize-space(ntx:SeatingCapacity)) + number(normalize-space(ntx:StandingCapacity))">
+        <sch:assert test="number(normalize-space(ntx:TotalCapacity)) = number(normalize-space(ntx:SeatingCapacity)) + number(normalize-space(ntx:StandingCapacity))">
             TotalCapacity moet gelijk zijn aan SeatingCapacity plus StandingCapacity
-        </assert>
+        </sch:assert>
 
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ResourceFrame/PassengerCapacity.sch
+++ b/sch/DRG/ResourceFrame/PassengerCapacity.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.PassengerCapacity" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:vehicleTypes/ntx:VehicleType/ntx:capacities/ntx:PassengerCapacity">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:vehicleTypes/ntx:VehicleType/ntx:capacities/ntx:PassengerCapacity">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/ResponsibilitySet.sch
+++ b/sch/DRG/ResourceFrame/ResponsibilitySet.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.ResponsibilitySet" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:responsibilitySets/ntx:ResponsibilitySet">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:responsibilitySets/ntx:ResponsibilitySet">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/ServiceFacilitySet.sch
+++ b/sch/DRG/ResourceFrame/ServiceFacilitySet.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.ServiceFacilitySet" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:ServiceFacilitySet">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:ServiceFacilitySet">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/ServiceFacilitySet.sch
+++ b/sch/DRG/ResourceFrame/ServiceFacilitySet.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="DRG.ResourceFrame.OperationalContext" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+<sch:pattern id="DRG.ResourceFrame.ServiceFacilitySet" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:ServiceFacilitySet">
         <!-- Variables for use in business rule -->
 
@@ -6,15 +6,15 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="matches(normalize-space(/ntx:PassengerCommsFacilityList), '[powerSupplySockets|freeWif]')">Het NL-profiel ondersteunt alleen de volgende waardes voor PassengerCommsFacilityList: powerSupplySockets | freeWif</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:PassengerCommsFacilityList), '^(powerSupplySockets|freeWifi)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor PassengerCommsFacilityList: powerSupplySockets | freeWifi</sch:assert>
 
         <!-- B -->
-        <sch:assert test="matches(normalize-space(/ntx:SanitaryFacilityList), '[toilet|wheelchairAccessToilet]')">Het NL-profiel ondersteunt alleen de volgende waardes voor SanitaryFacilityList: toilet | wheelchairAccessToilet</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:SanitaryFacilityList), '^(toilet|wheelchairAccessToilet)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor SanitaryFacilityList: toilet | wheelchairAccessToilet</sch:assert>
 
         <!-- C -->
-        <sch:assert test="matches(normalize-space(/ntx:TicketingServiceFacilityList), '[collection]')">Het NL-profiel ondersteunt alleen de volgende waardes voor TicketingServiceFacilityList: collection</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:TicketingServiceFacilityList), '^(collection)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor TicketingServiceFacilityList: collection</sch:assert>
 
         <!-- D -->
-        <sch:assert test="matches(normalize-space(/ntx:VehicleAccessFacilityList), '[wheelchairLift|manualRamp|automaticRamp|steps|slidingStep|narrowEntrance|validator]')">Het NL-profiel ondersteunt alleen de volgende waardes voor VehicleAccessFacilityList: wheelchairLift | manualRamp | automaticRamp | steps | slidingStep | narrowEntrance | validator</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:VehicleAccessFacilityList), '^(wheelchairLift|manualRamp|automaticRamp|steps|slidingStep|narrowEntrance|validator)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor VehicleAccessFacilityList: wheelchairLift | manualRamp | automaticRamp | steps | slidingStep | narrowEntrance | validator</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ResourceFrame/TransportAdministrativeZone.sch
+++ b/sch/DRG/ResourceFrame/TransportAdministrativeZone.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.TransportAdministrativeZone" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:zones/ntx:TransportAdministrativeZone">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:zones/ntx:TransportAdministrativeZone">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/ResourceFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.ResourceFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_BASELINE']/ntx:frames/ntx:ResourceFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_RESOURCE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_RESOURCE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_RESOURCE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_RESOURCE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ResourceFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/ResourceFrame/TypeOfFrameRef.sch
@@ -1,6 +1,0 @@
-<sch:pattern id="DRG.ResourceFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:CompositeFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_BASELINE']/ntx:frames/ntx:ResourceFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_RESOURCE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_RESOURCE".</sch:assert>
-        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
-    </sch:rule>
-</sch:pattern>

--- a/sch/DRG/ResourceFrame/TypeOfProductCategory.sch
+++ b/sch/DRG/ResourceFrame/TypeOfProductCategory.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.TypeOfProductCategory" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:typesOfValue/ntx:TypeOfProductCategory">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:typesOfValue/ntx:TypeOfProductCategory">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/VehicleType.sch
+++ b/sch/DRG/ResourceFrame/VehicleType.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ResourceFrame.VehicleType" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ResourceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_RESOURCE']/ntx:vehicleTypes/ntx:VehicleType">
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:vehicleTypes/ntx:VehicleType">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ResourceFrame/VehicleType.sch
+++ b/sch/DRG/ResourceFrame/VehicleType.sch
@@ -14,9 +14,9 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert xmlns:sch="http://purl.oclc.org/dsdl/schematron" test="matches(normalize-space(/ntx:FuelType), '[petrol|diesel|naturalGas|biodiesel|electricity|hydrogen|other]')">Het NL-profiel ondersteunt alleen de volgende waardes voor FuelType: petrol | diesel | naturalGas | biodiesel | electricity | hydrogen | other</sch:assert>
+        <sch:assert test="matches(normalize-space(ntx:FuelType), '^(petrol|diesel|naturalGas|biodiesel|electricity|hydrogen|other)$')">Het NL-profiel ondersteunt alleen de volgende waardes voor FuelType: petrol | diesel | naturalGas | biodiesel | electricity | hydrogen | other</sch:assert>
 
         <!-- B -->
-        <sch:assert test="/ntx:capacities[count(ntx:PassengerCapacity)=1] or /ntx:capacities[count(ntx:PassengerCapacityRef)=1]">Altijd 1 embedded PassengerCapacity element OF 1 PassengerCapacityRef verwijzing opnemen</sch:assert>
+        <sch:assert test="ntx:capacities[count(ntx:PassengerCapacity)=1] or ntx:capacities[count(ntx:PassengerCapacityRef)=1]">Altijd 1 embedded PassengerCapacity element OF 1 PassengerCapacityRef verwijzing opnemen</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceCalendarFrame/DayType.sch
+++ b/sch/DRG/ServiceCalendarFrame/DayType.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceCalendarFrame.DayType" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceCalendarFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_CALENDAR']/ntx:dayTypes/ntx:DayType">
+    <sch:rule context="ntx:ServiceCalendarFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:dayTypes/ntx:DayType">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceCalendarFrame/DayTypeAssignment.sch
+++ b/sch/DRG/ServiceCalendarFrame/DayTypeAssignment.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceCalendarFrame.DayTypeAssignment" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceCalendarFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_CALENDAR']/ntx:dayTypeAssignments/ntx:DayTypeAssignment">
+    <sch:rule context="ntx:ServiceCalendarFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:dayTypeAssignments/ntx:DayTypeAssignment">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceCalendarFrame/DayTypeAssignment.sch
+++ b/sch/DRG/ServiceCalendarFrame/DayTypeAssignment.sch
@@ -3,8 +3,6 @@
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->
-        <sch:assert test="ntx:Date">Date is verplicht</sch:assert>
-        <sch:assert test="ntx:DayTypeRef">DayTypeRef is verplicht</sch:assert>
 
         <!-- Other business rules -->
     </sch:rule>

--- a/sch/DRG/ServiceCalendarFrame/Timeband.sch
+++ b/sch/DRG/ServiceCalendarFrame/Timeband.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceCalendarFrame.Timeband" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceCalendarFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_CALENDAR']/ntx:timebands/ntx:Timeband">
+    <sch:rule context="ntx:ServiceCalendarFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:timebands/ntx:Timeband">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceCalendarFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/ServiceCalendarFrame/TypeOfFrameRef.sch
@@ -1,6 +1,0 @@
-<sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
-        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
-    </sch:rule>
-</sch:pattern>

--- a/sch/DRG/ServiceCalendarFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/ServiceCalendarFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/AccessibilityAssessment-limitations.sch
+++ b/sch/DRG/ServiceFrame/AccessibilityAssessment-limitations.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.AccessibilityAssessment-limitations" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:lines/ntx:Line/ntx:AccessibilityAssessment/ntx:limitations">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:lines/ntx:Line/ntx:AccessibilityAssessment/ntx:limitations">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/AccessibilityAssessment.sch
+++ b/sch/DRG/ServiceFrame/AccessibilityAssessment.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.AccessibilityAssessment" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:lines/ntx:Line/ntx:AccessibilityAssessment">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:lines/ntx:Line/ntx:AccessibilityAssessment">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/AccessibilityLimitation.sch
+++ b/sch/DRG/ServiceFrame/AccessibilityLimitation.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.AccessibilityAssessment-limitations-AccessibilityLimitation" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:lines/ntx:Line/ntx:AccessibilityAssessment/ntx:limitations/ntx:AccessibilityLimitation">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:lines/ntx:Line/ntx:AccessibilityAssessment/ntx:limitations/ntx:AccessibilityLimitation">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/DeadRunJourneyPattern.sch
+++ b/sch/DRG/ServiceFrame/DeadRunJourneyPattern.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.DeadRunJourneyPattern" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:journeyPatterns/ntx:DeadRunJourneyPattern">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:journeyPatterns/ntx:DeadRunJourneyPattern">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/DestinationDisplay.sch
+++ b/sch/DRG/ServiceFrame/DestinationDisplay.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.DestinationDisplay" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:destinationDisplays/ntx:DestinationDisplay">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:destinationDisplays/ntx:DestinationDisplay">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/DestinationDisplayVariant.sch
+++ b/sch/DRG/ServiceFrame/DestinationDisplayVariant.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.DestinationDisplayVariant" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:destinationDisplays/ntx:DestinationDisplay/ntx:variants/ntx:DestinationDisplayVariant">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:destinationDisplays/ntx:DestinationDisplay/ntx:variants/ntx:DestinationDisplayVariant">
         <!-- Variables for use in business rule -->
         <sch:let name="max-length" value="number(substring(ntx:Extensions/ntx:MaxLength/text(),string-length('BISON:DisplayTextLength:')+1))"/>
 

--- a/sch/DRG/ServiceFrame/FlexibleStopAssignment.sch
+++ b/sch/DRG/ServiceFrame/FlexibleStopAssignment.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.FlexibleStopAssignment" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:stopAssignments/ntx:FlexibleStopAssignment">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:stopAssignments/ntx:FlexibleStopAssignment">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/JourneyLayover.sch
+++ b/sch/DRG/ServiceFrame/JourneyLayover.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.JourneyLayover" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:timeDemandTypes/ntx:TimeDemandType/ntx:layovers/ntx:JourneyLayover">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:timeDemandTypes/ntx:TimeDemandType/ntx:layovers/ntx:JourneyLayover">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/JourneyRunTime.sch
+++ b/sch/DRG/ServiceFrame/JourneyRunTime.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.JourneyRunTime" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:timeDemandTypes/ntx:TimeDemandType/ntx:runtimes/ntx:JourneyRunTime">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:timeDemandTypes/ntx:TimeDemandType/ntx:runtimes/ntx:JourneyRunTime">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/JourneyWaitTime.sch
+++ b/sch/DRG/ServiceFrame/JourneyWaitTime.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.JourneyWaitTime" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:timeDemandTypes/ntx:TimeDemandType/ntx:waitTimes/ntx:JourneyWaitTime">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:timeDemandTypes/ntx:TimeDemandType/ntx:waitTimes/ntx:JourneyWaitTime">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/Line.sch
+++ b/sch/DRG/ServiceFrame/Line.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.Line" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:lines/ntx:Line">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:lines/ntx:Line">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->
@@ -7,7 +7,8 @@
         <sch:assert test="ntx:TransportMode">TransportMode is verplicht</sch:assert>
         <sch:assert test="ntx:privateCodes/ntx:PrivateCode[@type='LinePlanningNumber']">PrivateCode van type 'LinePlanningNumber' is verplicht</sch:assert>
         <sch:assert test="ntx:OperatorRef">OperatorRef is verplicht</sch:assert>
-        <sch:assert test="ntx:TypeOfServiceRef">TypeOfServiceRef is verplicht</sch:assert>
+        <!-- TypeOfServiceRef is optioneel; indien aanwezig wordt de waarde gecheckt -->
+        <sch:assert test="not(ntx:TypeOfServiceRef) or ntx:TypeOfServiceRef[@ref!='']">TypeOfServiceRef is optioneel, maar indien aanwezig mag ref niet leeg zijn</sch:assert>
         <sch:assert test="ntx:Monitored">Monitored is verplicht</sch:assert>
         <sch:assert test="ntx:AccessibilityAssessment">AccessibilityAssessment is verplicht</sch:assert>
 

--- a/sch/DRG/ServiceFrame/Notice.sch
+++ b/sch/DRG/ServiceFrame/Notice.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.Notice" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:notices/ntx:Notice">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:notices/ntx:Notice">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/NoticeAssignment.sch
+++ b/sch/DRG/ServiceFrame/NoticeAssignment.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.NoticeAssignment" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:noticeAssignments/ntx:NoticeAssignment">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:noticeAssignments/ntx:NoticeAssignment">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/PassengerStopAssignment.sch
+++ b/sch/DRG/ServiceFrame/PassengerStopAssignment.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.PassengerStopAssignment" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:stopAssignments/ntx:PassengerStopAssignment">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:stopAssignments/ntx:PassengerStopAssignment">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/PassengerStopAssignment.sch
+++ b/sch/DRG/ServiceFrame/PassengerStopAssignment.sch
@@ -7,8 +7,6 @@
         <sch:assert test="ntx:QuayRef">QuayRef is verplicht</sch:assert>
 
         <!-- Other business rules -->
-        <!-- A -->
-        <sch:assert test="ntx:QuayRef">QuayRef is verplicht</sch:assert>
 
         <!-- B -->
         <!-- TODO Elke ScheduledStopPoint dient exact één keer voor te komen in de lijst met PassengerStopAssignments.-->

--- a/sch/DRG/ServiceFrame/PointProjection.sch
+++ b/sch/DRG/ServiceFrame/PointProjection.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.PointProjection" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']//ntx:ScheduledStopPoint/ntx:projections/ntx:PointProjection">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]//ntx:ScheduledStopPoint/ntx:projections/ntx:PointProjection">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/Route.sch
+++ b/sch/DRG/ServiceFrame/Route.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.Route" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:routes/ntx:Route">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:routes/ntx:Route">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/Route.sch
+++ b/sch/DRG/ServiceFrame/Route.sch
@@ -9,7 +9,7 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="count(ntx:PointOnRoute)>1">Er wordt een minimum van twee PointOnRoute elementen verwacht</sch:assert>
+        <sch:assert test="count(ntx:pointsInSequence/ntx:PointOnRoute)>1">Er wordt een minimum van twee PointOnRoute elementen verwacht</sch:assert>
 
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/RouteLink.sch
+++ b/sch/DRG/ServiceFrame/RouteLink.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.RouteLink" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:routeLinks/ntx:RouteLink">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:routeLinks/ntx:RouteLink">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/RoutePoint.sch
+++ b/sch/DRG/ServiceFrame/RoutePoint.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.RoutePoint" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:routePoints/ntx:RoutePoint">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:routePoints/ntx:RoutePoint">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/ScheduledStopPoint.sch
+++ b/sch/DRG/ServiceFrame/ScheduledStopPoint.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.ScheduledStopPoint" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:scheduledStopPoints/ntx:ScheduledStopPoint">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:scheduledStopPoints/ntx:ScheduledStopPoint">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/ServiceJourneyPattern.sch
+++ b/sch/DRG/ServiceFrame/ServiceJourneyPattern.sch
@@ -8,7 +8,5 @@
         <sch:assert test="ntx:pointsInSequence[count(*)>1]">Er moeten minimaal twee punten opgenomen zijn in de pointsInSequence (StopPointInJourneyPattern en/of TimingPointInJourneyPattern)</sch:assert>
 
         <!-- Other business rules -->
-        <!-- A -->
-        <sch:assert test="ntx:pointsInSequence[count(*)>1]">Er moeten minimaal twee punten opgenomen zijn in de pointsInSequence (StopPointInJourneyPattern en/of TimingPointInJourneyPattern)</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/ServiceJourneyPattern.sch
+++ b/sch/DRG/ServiceFrame/ServiceJourneyPattern.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.ServiceJourneyPattern" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:journeyPatterns/ntx:ServiceJourneyPattern">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:journeyPatterns/ntx:ServiceJourneyPattern">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/StopArea.sch
+++ b/sch/DRG/ServiceFrame/StopArea.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.StopArea" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:stopAreas/ntx:StopArea">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:stopAreas/ntx:StopArea">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/StopArea.sch
+++ b/sch/DRG/ServiceFrame/StopArea.sch
@@ -7,6 +7,6 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="ntx:privateCodes/ntx:PrivateCode[@type='UserStopAreaCode']/text()=''">De waarde van de PrivateCode van type 'UserStopAreaCode' mag niet leeg zijn</sch:assert>
+        <sch:assert test="ntx:privateCodes/ntx:PrivateCode[@type='UserStopAreaCode']/text()!=''">De waarde van de PrivateCode van type 'UserStopAreaCode' mag niet leeg zijn</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/StopPointInJourneyPattern.sch
+++ b/sch/DRG/ServiceFrame/StopPointInJourneyPattern.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.StopPointInJourneyPattern" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:StopPointInJourneyPattern">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:StopPointInJourneyPattern">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/TimeDemandType.sch
+++ b/sch/DRG/ServiceFrame/TimeDemandType.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.TimeDemandType" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:timeDemandTypes/ntx:TimeDemandType">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:timeDemandTypes/ntx:TimeDemandType">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/TimingLink.sch
+++ b/sch/DRG/ServiceFrame/TimingLink.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.TimingLink" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:timingLinks/ntx:TimingLink">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:timingLinks/ntx:TimingLink">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/TimingPoint.sch
+++ b/sch/DRG/ServiceFrame/TimingPoint.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="DRG.ServiceFrame.TimingPoint" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="DRG.ServiceFrame.TimingPoint" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:timingPoints/ntx:TimingPoint">
         <!-- Variables for use in business rule -->
 
@@ -9,7 +9,7 @@
 
         <!-- Other business rules -->
         <!-- A -->
-        <sch:assert test="ntx:privateCodes/ntx:PrivateCode[@type='UserStopCode']/text()=''">De waarde van de PrivateCode van type 'UserStopCode' mag niet leeg zijn</sch:assert>
+        <sch:assert test="ntx:privateCodes/ntx:PrivateCode[@type='UserStopCode']/text()!=''">De waarde van de PrivateCode van type 'UserStopCode' mag niet leeg zijn</sch:assert>
 
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/TimingPoint.sch
+++ b/sch/DRG/ServiceFrame/TimingPoint.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.TimingPoint" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:timingPoints/ntx:TimingPoint">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:timingPoints/ntx:TimingPoint">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/TimingPointInJourneyPattern.sch
+++ b/sch/DRG/ServiceFrame/TimingPointInJourneyPattern.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.TimingPointInJourneyPattern" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:TimingPointInJourneyPattern">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:TimingPointInJourneyPattern">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/ServiceFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/ServiceFrame/TypeOfFrameRef.sch
@@ -1,6 +1,0 @@
-<sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
-        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
-    </sch:rule>
-</sch:pattern>

--- a/sch/DRG/ServiceFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/ServiceFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/ServiceFrame/Via.sch
+++ b/sch/DRG/ServiceFrame/Via.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.ServiceFrame.Via" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:ServiceFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_SERVICE']/ntx:destinationDisplays/ntx:DestinationDisplay//ntx:Via">
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:destinationDisplays/ntx:DestinationDisplay//ntx:Via">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/TimetableFrame/AvailabilityCondition.sch
+++ b/sch/DRG/TimetableFrame/AvailabilityCondition.sch
@@ -1,10 +1,10 @@
-<sch:pattern id="DRG.TimetableFrame.AvailabilityCondition" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="DRG.TimetableFrame.AvailabilityCondition" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:contentValidityConditions/ntx:AvailabilityCondition">
         <!-- Variables for use in business rule -->
-        <let name="from" value="xs:date(ntx:FromDate)"/>
-        <let name="to" value="xs:date(ntx:ToDate)"/>
-        <let name="bits" value="replace(normalize-space(ntx:ValidDayBits), '\s+', '')"/>
-        <let name="daysInclusive" value="floor(( $to - $from ) div xs:dayTimeDuration('P1D')) + 1"/>
+        <sch:let name="from" value="xs:date(ntx:FromDate)"/>
+        <sch:let name="to" value="xs:date(ntx:ToDate)"/>
+        <sch:let name="bits" value="replace(normalize-space(ntx:ValidDayBits), '\s+', '')"/>
+        <sch:let name="daysInclusive" value="floor(( $to - $from ) div xs:dayTimeDuration('P1D')) + 1"/>
 
         <!-- Cardinality and data-type constraints -->
         <sch:assert test="ntx:FromDate">FromDate is verplicht</sch:assert>
@@ -16,9 +16,9 @@
         <!-- De ToDate van de AvailabilityCondition dient ná de FromDate te liggen óf hieraan gelijk te zijn. -->
 
         <!-- B -->
-        <assert test="string-length($bits)=$daysInclusive">
-            Lengte van ValidDayBits (<value-of select="string-length($bits)"/>) moet gelijk zijn aan het aantal dagen tussen FromDate en ToDate (inclusief) (<value-of select="$daysInclusive"/>).
-        </assert>
+        <sch:assert test="string-length($bits)=$daysInclusive">
+            Lengte van ValidDayBits (<sch:value-of select="string-length($bits)"/>) moet gelijk zijn aan het aantal dagen tussen FromDate en ToDate (inclusief) (<sch:value-of select="$daysInclusive"/>).
+        </sch:assert>
 
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/TimetableFrame/AvailabilityCondition.sch
+++ b/sch/DRG/TimetableFrame/AvailabilityCondition.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.TimetableFrame.AvailabilityCondition" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:contentValidityConditions/ntx:AvailabilityCondition">
+    <sch:rule context="ntx:TimetableFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:contentValidityConditions/ntx:AvailabilityCondition">
         <!-- Variables for use in business rule -->
         <sch:let name="from" value="xs:dateTime(ntx:FromDate)"/>
         <sch:let name="to" value="xs:dateTime(ntx:ToDate)"/>

--- a/sch/DRG/TimetableFrame/AvailabilityCondition.sch
+++ b/sch/DRG/TimetableFrame/AvailabilityCondition.sch
@@ -1,8 +1,8 @@
 <sch:pattern id="DRG.TimetableFrame.AvailabilityCondition" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:contentValidityConditions/ntx:AvailabilityCondition">
         <!-- Variables for use in business rule -->
-        <sch:let name="from" value="xs:date(ntx:FromDate)"/>
-        <sch:let name="to" value="xs:date(ntx:ToDate)"/>
+        <sch:let name="from" value="xs:dateTime(ntx:FromDate)"/>
+        <sch:let name="to" value="xs:dateTime(ntx:ToDate)"/>
         <sch:let name="bits" value="replace(normalize-space(ntx:ValidDayBits), '\s+', '')"/>
         <sch:let name="daysInclusive" value="floor(( $to - $from ) div xs:dayTimeDuration('P1D')) + 1"/>
 

--- a/sch/DRG/TimetableFrame/DeadRun.sch
+++ b/sch/DRG/TimetableFrame/DeadRun.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="DRG.TimetableFrame.DeadRun" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="DRG.TimetableFrame.DeadRun" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:vehicleJourneys/ntx:DeadRun">
         <!-- Variables for use in business rule -->
 

--- a/sch/DRG/TimetableFrame/DeadRun.sch
+++ b/sch/DRG/TimetableFrame/DeadRun.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.TimetableFrame.DeadRun" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:vehicleJourneys/ntx:DeadRun">
+    <sch:rule context="ntx:TimetableFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:vehicleJourneys/ntx:DeadRun">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/TimetableFrame/ServiceJourney.sch
+++ b/sch/DRG/TimetableFrame/ServiceJourney.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="DRG.TimetableFrame.ServiceJourney" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="DRG.TimetableFrame.ServiceJourney" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:vehicleJourneys/ntx:ServiceJourney">
         <!-- Variables for use in business rule -->
 

--- a/sch/DRG/TimetableFrame/ServiceJourney.sch
+++ b/sch/DRG/TimetableFrame/ServiceJourney.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.TimetableFrame.ServiceJourney" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:vehicleJourneys/ntx:ServiceJourney">
+    <sch:rule context="ntx:TimetableFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:vehicleJourneys/ntx:ServiceJourney">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/TimetableFrame/ServiceJourneyInterchange.sch
+++ b/sch/DRG/TimetableFrame/ServiceJourneyInterchange.sch
@@ -1,4 +1,4 @@
-<sch:pattern id="TimetableFrame-ServiceJourneyInterchange" xmlns:sch="http://purl.oclc.org/dsdl/schematron">>
+<sch:pattern id="TimetableFrame-ServiceJourneyInterchange" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:journeyInterchanges/ntx:ServiceJourneyInterchange">
         <!-- Variables for use in business rule -->
 

--- a/sch/DRG/TimetableFrame/ServiceJourneyInterchange.sch
+++ b/sch/DRG/TimetableFrame/ServiceJourneyInterchange.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="TimetableFrame-ServiceJourneyInterchange" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:TimetableFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE']/ntx:journeyInterchanges/ntx:ServiceJourneyInterchange">
+    <sch:rule context="ntx:TimetableFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:journeyInterchanges/ntx:ServiceJourneyInterchange">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/TimetableFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/TimetableFrame/TypeOfFrameRef.sch
@@ -1,6 +1,0 @@
-<sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
-        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
-    </sch:rule>
-</sch:pattern>

--- a/sch/DRG/TimetableFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/TimetableFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/TypeOfFrameRefConsistency.sch
+++ b/sch/DRG/TypeOfFrameRefConsistency.sch
@@ -1,0 +1,49 @@
+<!-- Optional TypeOfFrameRef consistency checks.
+     TypeOfFrameRef is no longer required for NL profile selection (that role is now
+     fulfilled by Extensions/ProfileMarker). However, when TypeOfFrameRef IS present,
+     its value must be consistent with the frame type and the declared profile. -->
+<sch:pattern id="DRG.TypeOfFrameRefConsistency" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+
+    <!-- CompositeFrame: if TypeOfFrameRef is present, it must match NL_TT_BASELINE -->
+    <sch:rule context="ntx:CompositeFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:TypeOfFrameRef">
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef is optioneel, maar indien aanwezig moet ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE" zijn voor een NL-BISON-TIMETABLE CompositeFrame.</sch:assert>
+        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef is optioneel, maar indien aanwezig moet version="9.4.0" zijn.</sch:assert>
+    </sch:rule>
+
+    <!-- ResourceFrame: if TypeOfFrameRef is present, it must match NL_TT_RESOURCE -->
+    <sch:rule context="ntx:ResourceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:TypeOfFrameRef">
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_RESOURCE'">TypeOfFrameRef is optioneel, maar indien aanwezig moet ref="NL:BISON:TypeOfFrame:NL_TT_RESOURCE" zijn voor een ResourceFrame in het NL-BISON-TIMETABLE profiel.</sch:assert>
+        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef is optioneel, maar indien aanwezig moet version="9.4.0" zijn.</sch:assert>
+    </sch:rule>
+
+    <!-- ServiceCalendarFrame: if TypeOfFrameRef is present, it must match NL_TT_CALENDAR -->
+    <sch:rule context="ntx:ServiceCalendarFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:TypeOfFrameRef">
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_CALENDAR'">TypeOfFrameRef is optioneel, maar indien aanwezig moet ref="NL:BISON:TypeOfFrame:NL_TT_CALENDAR" zijn voor een ServiceCalendarFrame in het NL-BISON-TIMETABLE profiel.</sch:assert>
+        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef is optioneel, maar indien aanwezig moet version="9.4.0" zijn.</sch:assert>
+    </sch:rule>
+
+    <!-- ServiceFrame: if TypeOfFrameRef is present, it must match NL_TT_SERVICE -->
+    <sch:rule context="ntx:ServiceFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:TypeOfFrameRef">
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_SERVICE'">TypeOfFrameRef is optioneel, maar indien aanwezig moet ref="NL:BISON:TypeOfFrame:NL_TT_SERVICE" zijn voor een ServiceFrame in het NL-BISON-TIMETABLE profiel.</sch:assert>
+        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef is optioneel, maar indien aanwezig moet version="9.4.0" zijn.</sch:assert>
+    </sch:rule>
+
+    <!-- TimetableFrame: if TypeOfFrameRef is present, it must match NL_TT_TIMETABLE -->
+    <sch:rule context="ntx:TimetableFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:TypeOfFrameRef">
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_TIMETABLE'">TypeOfFrameRef is optioneel, maar indien aanwezig moet ref="NL:BISON:TypeOfFrame:NL_TT_TIMETABLE" zijn voor een TimetableFrame in het NL-BISON-TIMETABLE profiel.</sch:assert>
+        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef is optioneel, maar indien aanwezig moet version="9.4.0" zijn.</sch:assert>
+    </sch:rule>
+
+    <!-- InfrastructureFrame: if TypeOfFrameRef is present, it must match NL_TT_INFRA -->
+    <sch:rule context="ntx:InfrastructureFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:TypeOfFrameRef">
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_INFRA'">TypeOfFrameRef is optioneel, maar indien aanwezig moet ref="NL:BISON:TypeOfFrame:NL_TT_INFRA" zijn voor een InfrastructureFrame in het NL-BISON-TIMETABLE profiel.</sch:assert>
+        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef is optioneel, maar indien aanwezig moet version="9.4.0" zijn.</sch:assert>
+    </sch:rule>
+
+    <!-- VehicleScheduleFrame: if TypeOfFrameRef is present, it must match NL_TT_VEHICLE -->
+    <sch:rule context="ntx:VehicleScheduleFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:TypeOfFrameRef">
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_VEHICLE'">TypeOfFrameRef is optioneel, maar indien aanwezig moet ref="NL:BISON:TypeOfFrame:NL_TT_VEHICLE" zijn voor een VehicleScheduleFrame in het NL-BISON-TIMETABLE profiel.</sch:assert>
+        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef is optioneel, maar indien aanwezig moet version="9.4.0" zijn.</sch:assert>
+    </sch:rule>
+
+</sch:pattern>

--- a/sch/DRG/VehicleScheduleFrame/Block.sch
+++ b/sch/DRG/VehicleScheduleFrame/Block.sch
@@ -1,5 +1,5 @@
 <sch:pattern id="DRG.VehicleScheduleFrame.Block" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:VehicleScheduleFrame[ntx:TypeOfFrameRef/@ref='NL:BISON:TypeOfFrame:NL_TT_VEHICLE']/ntx:blocks/ntx:Block">
+    <sch:rule context="ntx:VehicleScheduleFrame[ntx:Extensions/bpf:ProfileMarker[bpf:ProfileCode='NL-BISON-TIMETABLE']]/ntx:blocks/ntx:Block">
         <!-- Variables for use in business rule -->
 
         <!-- Cardinality and data-type constraints -->

--- a/sch/DRG/VehicleScheduleFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/VehicleScheduleFrame/TypeOfFrameRef.sch
@@ -1,6 +1,0 @@
-<sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
-    <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
-        <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
-    </sch:rule>
-</sch:pattern>

--- a/sch/DRG/VehicleScheduleFrame/TypeOfFrameRef.sch
+++ b/sch/DRG/VehicleScheduleFrame/TypeOfFrameRef.sch
@@ -1,6 +1,6 @@
 <sch:pattern id="DRG.CompositeFrame.TypeOfFrameRef" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <sch:rule context="ntx:CompositeFrame/ntx:TypeOfFrameRef">
-        <sch:assert test="normalize-space(@ref)='BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
+        <sch:assert test="normalize-space(@ref)='NL:BISON:TypeOfFrame:NL_TT_BASELINE'">TypeOfFrameRef must have ref="NL:BISON:TypeOfFrame:NL_TT_BASELINE".</sch:assert>
         <sch:assert test="normalize-space(@version)='9.4.0'">TypeOfFrameRef must have version="9.4.0".</sch:assert>
     </sch:rule>
 </sch:pattern>

--- a/sch/DRG/dienstregeling-export.sch
+++ b/sch/DRG/dienstregeling-export.sch
@@ -95,7 +95,7 @@
 
     <sch:pattern>
         <sch:rule context="ntx:PublicationDelivery">
-            <sch:assert test="PublicationTimestamp">PublicationTimestamp is verplicht</sch:assert>
+            <sch:assert test="ntx:PublicationTimestamp">PublicationTimestamp is verplicht</sch:assert>
         </sch:rule>
     </sch:pattern>
 </sch:schema>

--- a/sch/DRG/dienstregeling-export.sch
+++ b/sch/DRG/dienstregeling-export.sch
@@ -6,16 +6,22 @@
     <!-- Namespaces used in NeTEx NL -->
     <sch:ns prefix="ntx" uri="http://www.netex.org.uk/netex"/>
     <sch:ns prefix="gml" uri="http://www.opengis.net/gml/3.2"/>
+    <!-- BISON profile marker namespace (Extensions/ProfileMarker) -->
+    <sch:ns prefix="bpf" uri="urn:bison:profile"/>
+
+    <!-- Profile marker validation -->
+    <sch:include href="ProfileMarker.sch"/>
+
+    <!-- Optional TypeOfFrameRef consistency checks (when TypeOfFrameRef is present) -->
+    <sch:include href="TypeOfFrameRefConsistency.sch"/>
 
     <!-- Include all frame-specific schematron schema -->
     <!-- Composite -->
 <!--    <sch:include href="CompositeFrame/FrameDefaults.sch"/>-->
     <sch:include href="CompositeFrame/ValidBetween.sch"/>
-    <sch:include href="CompositeFrame/TypeOfFrameRef.sch"/>
     <sch:include href="CompositeFrame/frames.sch"/>
 
     <!-- ResourceFrame -->
-    <sch:include href="ResourceFrame/TypeOfFrameRef.sch"/>
     <sch:include href="ResourceFrame/Authority.sch"/>
     <sch:include href="ResourceFrame/Branding.sch"/>
     <sch:include href="ResourceFrame/DataSource.sch"/>
@@ -30,11 +36,9 @@
     <sch:include href="ResourceFrame/VehicleType.sch"/>
 
     <!-- InfrastructureFrame -->
-    <sch:include href="InfrastructureFrame/TypeOfFrameRef.sch"/>
     <sch:include href="InfrastructureFrame/ActivationPoint.sch"/>
 
     <!-- ServiceFrame -->
-    <sch:include href="ServiceFrame/TypeOfFrameRef.sch"/>
     <sch:include href="ServiceFrame/AccessibilityAssessment.sch"/>
     <sch:include href="ServiceFrame/AccessibilityAssessment-limitations.sch"/>
     <sch:include href="ServiceFrame/AccessibilityLimitation.sch"/>
@@ -63,11 +67,9 @@
     <sch:include href="ServiceFrame/TimingLink.sch"/>
     <sch:include href="ServiceFrame/TimingPoint.sch"/>
     <sch:include href="ServiceFrame/TimingPointInJourneyPattern.sch"/>
-    <sch:include href="ServiceFrame/TypeOfFrameRef.sch"/>
     <sch:include href="ServiceFrame/Via.sch"/>
 
     <!-- TimetableFrame -->
-    <sch:include href="TimetableFrame/TypeOfFrameRef.sch"/>
     <sch:include href="TimetableFrame/AvailabilityCondition.sch"/>
     <sch:include href="TimetableFrame/DeadRun.sch"/>
     <sch:include href="TimetableFrame/ServiceJourney.sch"/>
@@ -75,13 +77,11 @@
     <sch:include href="TimetableFrame/vehicleJourneys.sch"/>
 
     <!-- ServiceCalendarFrame -->
-    <sch:include href="ServiceCalendarFrame/TypeOfFrameRef.sch"/>
     <sch:include href="ServiceCalendarFrame/DayType.sch"/>
     <sch:include href="ServiceCalendarFrame/DayTypeAssignment.sch"/>
     <sch:include href="ServiceCalendarFrame/Timeband.sch"/>
 
     <!-- VehicleScheduleFrame -->
-    <sch:include href="VehicleScheduleFrame/TypeOfFrameRef.sch"/>
     <sch:include href="VehicleScheduleFrame/Block.sch"/>
 
     <!-- Algemeen -->


### PR DESCRIPTION
Refactor NL NeTEx Schematron profile selection to use a local Extensions/ProfileMarker instead of TypeOfFrameRef as the primary selector. This decouples NL profile validation from external reference dependencies, keeps TypeOfFrameRef optional as semantic enrichment, and aligns validation more cleanly with a split where CEN XSD handles structure/references and Schematron handles NL profile/business rules.